### PR TITLE
AVIF and HEIC support using libheif-sharp 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,9 +16,12 @@ Supported image formats are:
 2. jpg
 3. gif
 4. webp
+5. avif *
+6. heic *
 
 The default image format is png.
-
+  
+  \*  [Libheif-sharp](https://github.com/0xC0000054/libheif-sharp) dependencies must be present. See **Windows Development Setup**.
 
 # Appsettings.json
 
@@ -97,5 +100,23 @@ Request a jpeg and resize to 800x400. Specifying just a width or height will kee
 ```
 /proxy/{url of the source image}?imgformat=jpeg&w=800&h=400
 ```
+
+# Windows Development Setup 
+Libheif-sharp requires some DLL files to function on Windows. The DLLs are required to use AVIF and HEIC functionality. Instructions for building the DLLs [here](https://0xc0000054.github.io/libheif-sharp/libheif_windows_build_vcpkg.html).
+
+
+Place the generated DLLs in the following two folders:
+
+```~\TownSuite.Web.ImageGen\bin\Debug\net6.0``` 
+
+```~\TownSuite.Web.ImageGen.Tests\bin\Debug\net6.0```
+
+### ***Important*** You need to install ***"Desktop devlopment with C++"*** in Visual Studio to build these DLLs. (~4 GB)
+
+![image](https://github.com/TownSuite/TownSuite.Web.ImageGen/assets/37007232/f2183a97-b05b-45e8-bd3a-4085d2bf9ed8)
+
+## Automated Windows Setup
+The powershell script ```libheif-windows-build.ps1``` automates this procedure. This script still requires **Desktop devlopment with C++** be installed through Visual Studio.
+
 
 

--- a/TownSuite.Web.ImageGen.Tests/DownloaderFake.cs
+++ b/TownSuite.Web.ImageGen.Tests/DownloaderFake.cs
@@ -1,4 +1,3 @@
-using SixLabors.ImageSharp;
 
 namespace TownSuite.Web.ImageGen.Tests;
 

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using SixLabors.ImageSharp;
+using TownSuite.Web.ImageGen;
 
 namespace TownSuite.Web.ImageGen.Tests;
 
@@ -43,14 +44,16 @@ public class GenerateIdenticonImageRepoTest
             "test_output");
         var results = await repo.Get(request);
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-
+        using var ms = new MemoryStream(results.imageData);
+        Image newImage; 
         if (imageformat == "avif" || imageformat == "heic")
         {
-            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
+            newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }
-
-        using var ms = new MemoryStream(results.imageData);
-        var newImage = await Image.LoadAsync(ms);
+        else
+        {
+            newImage = await Image.LoadAsync(ms);
+        }
         Assert.That(newImage.Height, Is.EqualTo(777));
         Assert.That(newImage.Width, Is.EqualTo(777));
     }

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -46,7 +46,7 @@ public class GenerateIdenticonImageRepoTest
         if (imageformat == "avif" || imageformat == "heic")
         {
             Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-            return;
+            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -14,8 +14,8 @@ public class GenerateIdenticonImageRepoTest
     {
     }
 
-    private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp" };
-    
+    private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
+
     [Test, TestCaseSource("ImageFormatCases")]
     public async Task Test1(string imageformat)
     {
@@ -42,6 +42,12 @@ public class GenerateIdenticonImageRepoTest
             "/avatar/hello",
             "test_output");
         var results = await repo.Get(request);
+
+        if (imageformat == "avif" || imageformat == "heic")
+        {
+            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
+            return;
+        }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -14,14 +14,12 @@ public class GenerateIdenticonImageRepoTest
 
     private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
 
-    [Test, TestCaseSource("ImageFormatCases")]
+    [Test, TestCaseSource(nameof(ImageFormatCases))]
     public async Task Test1(string imageformat)
     {
         var origImage = await Image.LoadAsync("assets/facility.jpg");
         Assert.That(origImage.Height, Is.EqualTo(365));
         Assert.That(origImage.Width, Is.EqualTo(800));
-        
-        var downloader = new DownloaderFake("image/jpeg");
         var repo = new GenerateIdenticonImageRepo(new Settings()
         {
             HttpCacheControlMaxAgeInMinutes = 5

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -46,7 +46,8 @@ public class GenerateIdenticonImageRepoTest
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         using var ms = new MemoryStream(results.imageData);
         Image newImage; 
-        if (imageformat == "avif" || imageformat == "heic")
+        if (ImageFormat.IsFormat(imageformat, ImageFormat.Format.avif) 
+            || ImageFormat.IsFormat(imageformat, ImageFormat.Format.heic))
         {
             newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -42,16 +42,15 @@ public class GenerateIdenticonImageRepoTest
             "/avatar/hello",
             "test_output");
         var results = await repo.Get(request);
+        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
 
         if (imageformat == "avif" || imageformat == "heic")
         {
-            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
             return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);
-        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         Assert.That(newImage.Height, Is.EqualTo(777));
         Assert.That(newImage.Width, Is.EqualTo(777));
     }

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -17,9 +17,6 @@ public class GenerateIdenticonImageRepoTest
     [Test, TestCaseSource(nameof(ImageFormatCases))]
     public async Task Test1(string imageformat)
     {
-        var origImage = await Image.LoadAsync("assets/facility.jpg");
-        Assert.That(origImage.Height, Is.EqualTo(365));
-        Assert.That(origImage.Width, Is.EqualTo(800));
         var repo = new GenerateIdenticonImageRepo(new Settings()
         {
             HttpCacheControlMaxAgeInMinutes = 5

--- a/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GenerateIdenticonImageRepoTest.cs
@@ -1,9 +1,6 @@
-using System.Net;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using SixLabors.ImageSharp;
-using TownSuite.Web.ImageGen;
 
 namespace TownSuite.Web.ImageGen.Tests;
 

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -1,6 +1,4 @@
-using System.Net;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using SixLabors.ImageSharp;
 

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -14,7 +14,7 @@ public class GeneratePlaceHolderImageRepoTest
     {
     }
 
-    private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp" };
+    private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
     
     [Test, TestCaseSource("ImageFormatCases")]
     public async Task Test1(string imageformat)
@@ -42,6 +42,12 @@ public class GeneratePlaceHolderImageRepoTest
             "/placeholder/hello",
             "test_output");
         var results = await repo.Get(request);
+
+        if (imageformat == "avif" || imageformat == "heic" )
+        {
+            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
+            return;
+        }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -45,7 +45,8 @@ public class GeneratePlaceHolderImageRepoTest
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         using var ms = new MemoryStream(results.imageData);
         Image newImage;
-        if (imageformat == "avif" || imageformat == "heic")
+        if (ImageFormat.IsFormat(imageformat, ImageFormat.Format.avif)
+            || ImageFormat.IsFormat(imageformat, ImageFormat.Format.heic))
         {
             newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -43,14 +43,16 @@ public class GeneratePlaceHolderImageRepoTest
             "test_output");
         var results = await repo.Get(request);
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-
+        using var ms = new MemoryStream(results.imageData);
+        Image newImage;
         if (imageformat == "avif" || imageformat == "heic")
         {
-            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
+            newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }
-
-        using var ms = new MemoryStream(results.imageData);
-        var newImage = await Image.LoadAsync(ms);
+        else
+        {
+            newImage = await Image.LoadAsync(ms);
+        }
         Assert.That(newImage.Height, Is.EqualTo(555));
         Assert.That(newImage.Width, Is.EqualTo(555));
     }

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -46,7 +46,7 @@ public class GeneratePlaceHolderImageRepoTest
         if (imageformat == "avif" || imageformat == "heic" )
         {
             Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-            return;
+            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -17,10 +17,6 @@ public class GeneratePlaceHolderImageRepoTest
     [Test, TestCaseSource(nameof(ImageFormatCases))]
     public async Task Test1(string imageformat)
     {
-        var origImage = await Image.LoadAsync("assets/facility.jpg");
-        Assert.That(origImage.Height, Is.EqualTo(365));
-        Assert.That(origImage.Width, Is.EqualTo(800));
-        
         var repo = new GeneratePlaceholderImageRepo(new Settings()
         {
             HttpCacheControlMaxAgeInMinutes = 5

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -14,14 +14,13 @@ public class GeneratePlaceHolderImageRepoTest
 
     private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
     
-    [Test, TestCaseSource("ImageFormatCases")]
+    [Test, TestCaseSource(nameof(ImageFormatCases))]
     public async Task Test1(string imageformat)
     {
         var origImage = await Image.LoadAsync("assets/facility.jpg");
         Assert.That(origImage.Height, Is.EqualTo(365));
         Assert.That(origImage.Width, Is.EqualTo(800));
         
-        var downloader = new DownloaderFake("image/jpeg");
         var repo = new GeneratePlaceholderImageRepo(new Settings()
         {
             HttpCacheControlMaxAgeInMinutes = 5

--- a/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/GeneratePlaceholderImageRepoTest.cs
@@ -42,16 +42,15 @@ public class GeneratePlaceHolderImageRepoTest
             "/placeholder/hello",
             "test_output");
         var results = await repo.Get(request);
+        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
 
-        if (imageformat == "avif" || imageformat == "heic" )
+        if (imageformat == "avif" || imageformat == "heic")
         {
-            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
             return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);
-        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         Assert.That(newImage.Height, Is.EqualTo(555));
         Assert.That(newImage.Width, Is.EqualTo(555));
     }

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -15,7 +15,7 @@ public class ImageProxyRepoTest
 
     private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
 
-    [Test, TestCaseSource("ImageFormatCases")]
+    [Test, TestCaseSource(nameof(ImageFormatCases))]
     public async Task Test1(string imageformat)
     {
         var origImage = await Image.LoadAsync("assets/facility.jpg");
@@ -57,7 +57,7 @@ public class ImageProxyRepoTest
         Assert.That(newImage.Width, Is.EqualTo(333));
     }
 
-    [Test, TestCaseSource("ImageFormatCases")]
+    [Test, TestCaseSource(nameof(ImageFormatCases))]
     public async Task ImageMaxResizeCanOnlyBeEqualOrLessThanImageOriginalSizeTest(string imageformat)
     {
         var origImage = await Image.LoadAsync("assets/facility.jpg");

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -44,14 +44,16 @@ public class ImageProxyRepoTest
             "test_output");
         var results = await repo.Get(request);
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-
+        using var ms = new MemoryStream(results.imageData);
+        Image newImage;
         if (imageformat == "avif" || imageformat == "heic")
         {
-            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
+            newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }
-
-        using var ms = new MemoryStream(results.imageData);
-        var newImage = await Image.LoadAsync(ms);
+        else
+        {
+            newImage = await Image.LoadAsync(ms);
+        }
         Assert.That(newImage.Height, Is.EqualTo(333));
         Assert.That(newImage.Width, Is.EqualTo(333));
     }
@@ -83,14 +85,16 @@ public class ImageProxyRepoTest
             "test_output");
         var results = await repo.Get(request);
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-
+        using var ms = new MemoryStream(results.imageData);
+        Image newImage;
         if (imageformat == "avif" || imageformat == "heic")
         {
-            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
+            newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }
-
-        using var ms = new MemoryStream(results.imageData);
-        var newImage = await Image.LoadAsync(ms);
+        else
+        {
+            newImage = await Image.LoadAsync(ms);
+        }
         Assert.That(newImage.Height, Is.EqualTo(365));
         Assert.That(newImage.Width, Is.EqualTo(800));
     }

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -43,16 +43,15 @@ public class ImageProxyRepoTest
             "/proxy/assets%2Ffacility.jpg",
             "test_output");
         var results = await repo.Get(request);
+        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
 
         if (imageformat == "avif" || imageformat == "heic")
         {
-            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
             return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);
-        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         Assert.That(newImage.Height, Is.EqualTo(333));
         Assert.That(newImage.Width, Is.EqualTo(333));
     }
@@ -83,16 +82,15 @@ public class ImageProxyRepoTest
             "/proxy/assets%2Ffacility.jpg",
             "test_output");
         var results = await repo.Get(request);
+        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
 
         if (imageformat == "avif" || imageformat == "heic")
         {
-            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
             return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);
-        Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         Assert.That(newImage.Height, Is.EqualTo(365));
         Assert.That(newImage.Width, Is.EqualTo(800));
     }

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -15,8 +15,9 @@ public class ImageProxyRepoTest
     {
     }
 
-    private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp" };
-    
+    private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
+
+
     [Test, TestCaseSource("ImageFormatCases")]
     public async Task Test1(string imageformat)
     {
@@ -43,6 +44,12 @@ public class ImageProxyRepoTest
             "/proxy/assets%2Ffacility.jpg",
             "test_output");
         var results = await repo.Get(request);
+
+        if (imageformat == "avif" || imageformat == "heic")
+        {
+            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
+            return;
+        }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);
@@ -77,6 +84,12 @@ public class ImageProxyRepoTest
             "/proxy/assets%2Ffacility.jpg",
             "test_output");
         var results = await repo.Get(request);
+
+        if (imageformat == "avif" || imageformat == "heic")
+        {
+            Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
+            return;
+        }
 
         using var ms = new MemoryStream(results.imageData);
         var newImage = await Image.LoadAsync(ms);

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -46,7 +46,8 @@ public class ImageProxyRepoTest
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         using var ms = new MemoryStream(results.imageData);
         Image newImage;
-        if (imageformat == "avif" || imageformat == "heic")
+        if (ImageFormat.IsFormat(imageformat, ImageFormat.Format.avif)
+           || ImageFormat.IsFormat(imageformat, ImageFormat.Format.heic))
         {
             newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }
@@ -87,7 +88,8 @@ public class ImageProxyRepoTest
         Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
         using var ms = new MemoryStream(results.imageData);
         Image newImage;
-        if (imageformat == "avif" || imageformat == "heic")
+        if (ImageFormat.IsFormat(imageformat, ImageFormat.Format.avif)
+           || ImageFormat.IsFormat(imageformat, ImageFormat.Format.heic))
         {
             newImage = HeifDecoder.ConvertHeifToSharp(ms);
         }

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -47,7 +47,7 @@ public class ImageProxyRepoTest
         if (imageformat == "avif" || imageformat == "heic")
         {
             Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-            return;
+            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);
@@ -87,7 +87,7 @@ public class ImageProxyRepoTest
         if (imageformat == "avif" || imageformat == "heic")
         {
             Assert.That(results.metadata.ContentType, Is.EqualTo($"image/{imageformat}"));
-            return;
+            return; // Decoding avif and heic is not supported yet. If decoding is added, test it here.
         }
 
         using var ms = new MemoryStream(results.imageData);

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -17,7 +17,6 @@ public class ImageProxyRepoTest
 
     private static string[] ImageFormatCases = new string[] { "jpeg", "png", "gif", "webp", "avif", "heic" };
 
-
     [Test, TestCaseSource("ImageFormatCases")]
     public async Task Test1(string imageformat)
     {

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -1,7 +1,5 @@
-using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using SixLabors.ImageSharp;
 

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 80
 EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS libheif-build
-RUN apk add --no-cache build-base git cmake yasm perl x265 x265-dev
+RUN apk add --no-cache build-base git cmake yasm perl libde265 libde265-dev x265 x265-dev
 WORKDIR /tmp
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 WORKDIR /tmp/aom
@@ -19,6 +19,7 @@ WORKDIR /app/libheif/build
 RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DWITH_EXAMPLES=OFF \
+    -DWITH_LIBDE265=ON \
     -DWITH_X265=ON \
     ..
 RUN make -j$(nproc)
@@ -36,6 +37,7 @@ FROM build AS publish
 RUN dotnet publish "TownSuite.Web.ImageGen.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
+COPY --from=libheif-build /usr/lib/libde265.so* /usr/lib/
 COPY --from=libheif-build /usr/lib/libx265.so* /usr/lib/
 COPY --from=libheif-build /usr/local/lib/libheif.so* /usr/local/lib
 COPY --from=libheif-build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /app/libheif/build
 RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DWITH_EXAMPLES=OFF \
-    -DWITH_LIBDE265=ON \
     -DWITH_X265=ON \
     ..
 RUN make -j$(nproc)
@@ -37,7 +36,6 @@ FROM build AS publish
 RUN dotnet publish "TownSuite.Web.ImageGen.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
-COPY --from=libheif-build /usr/lib/libde265.so* /usr/lib/
 COPY --from=libheif-build /usr/lib/libx265.so* /usr/lib/
 COPY --from=libheif-build /usr/local/lib/libheif.so* /usr/local/lib
 COPY --from=libheif-build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -37,7 +37,7 @@ FROM build AS publish
 RUN dotnet publish "TownSuite.Web.ImageGen.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
-COPY --from=libheif-build /usr/lib/libde265.so* /usr/local/lib/
+COPY --from=libheif-build /usr/lib/libde265.so* /usr/lib/
 COPY --from=libheif-build /usr/lib/libx265.so* /usr/lib/
 COPY --from=libheif-build /usr/local/lib/libheif.so* /usr/local/lib
 COPY --from=libheif-build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache build-base git cmake yasm perl x265 x265-dev
 WORKDIR /tmp
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 WORKDIR /tmp/aom
-RUN mkdir -p build && cd build && cmake .. && make -j4 && make install
+RUN mkdir -p build && cd build && cmake .. && make -j$(nproc) && make install
 WORKDIR /app
 RUN git clone --depth 1 https://github.com/strukturag/libheif.git
 WORKDIR /app/libheif
@@ -22,7 +22,7 @@ RUN cmake \
     -DWITH_LIBDE265=ON \
     -DWITH_X265=ON \
     ..
-RUN make
+RUN make -j$(nproc)
 RUN make install
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -5,6 +5,26 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS libheif-build
+RUN apk add --no-cache build-base git cmake yasm perl libde265 libde265-dev x265 x265-dev
+WORKDIR /tmp
+RUN git clone --depth 1 https://aomedia.googlesource.com/aom
+WORKDIR /tmp/aom
+RUN mkdir -p build && cd build && cmake .. && make -j4 && make install
+WORKDIR /app
+RUN git clone --depth 1 https://github.com/strukturag/libheif.git
+WORKDIR /app/libheif
+RUN mkdir build
+WORKDIR /app/libheif/build
+RUN cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_EXAMPLES=OFF \
+    -DWITH_LIBDE265=ON \
+    -DWITH_X265=ON \
+    ..
+RUN make
+RUN make install
+
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj", "TownSuite.Web.ImageGen/"]
@@ -17,6 +37,12 @@ FROM build AS publish
 RUN dotnet publish "TownSuite.Web.ImageGen.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
+COPY --from=libheif-build /usr/lib/libde265.so* /usr/local/lib/
+COPY --from=libheif-build /usr/lib/libx265.so* /usr/lib/
+COPY --from=libheif-build /usr/local/lib/libheif.so* /usr/local/lib
+COPY --from=libheif-build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=libheif-build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=libheif-build /usr/lib/libnuma.so.1 /usr/lib/libnuma.so.1
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "TownSuite.Web.ImageGen.dll"]

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 80
 EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS libheif-build
-RUN apk add --no-cache build-base git cmake yasm perl libde265 libde265-dev x265 x265-dev
+RUN apk add --no-cache build-base git cmake yasm perl x265 x265-dev
 WORKDIR /tmp
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 WORKDIR /tmp/aom

--- a/TownSuite.Web.ImageGen/HeifDecoder.cs
+++ b/TownSuite.Web.ImageGen/HeifDecoder.cs
@@ -1,0 +1,40 @@
+﻿using LibHeifSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp;
+using System.Runtime.InteropServices;
+
+namespace TownSuite.Web.ImageGen
+{
+    public static class HeifDecoder
+    {
+        public static Image<Rgba32> ConvertHeifToSharp(Stream stream)
+        {
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+   
+            using var heifContext = new HeifContext(ms.ToArray());
+            using var srcImageHandle = heifContext.GetPrimaryImageHandle();
+            using var srcImage = srcImageHandle.Decode(HeifColorspace.Rgb, HeifChroma.InterleavedRgba32);
+
+            var outImage = new Image<Rgba32>(srcImage.Width, srcImage.Height);
+
+            var planeData = srcImage.GetPlane(HeifChannel.Interleaved);
+            IntPtr startPtr = planeData.Scan0;
+            int stride = planeData.Stride;
+
+            for (int y = 0; y < srcImage.Height; y++)
+            {
+               for (int x = 0; x < srcImage.Width; x++)
+                {
+                   var ptr = startPtr + (y * stride) + (x * 4);
+                   var r = Marshal.ReadByte(ptr);
+                   var g = Marshal.ReadByte(ptr + 1);
+                   var b = Marshal.ReadByte(ptr + 2);
+                   var a = Marshal.ReadByte(ptr + 3);
+                   outImage[x, y] = new Rgba32(r, g, b, a);
+               }
+            }
+            return outImage;
+        }
+    }
+}

--- a/TownSuite.Web.ImageGen/HeifDecoder.cs
+++ b/TownSuite.Web.ImageGen/HeifDecoder.cs
@@ -36,5 +36,9 @@ namespace TownSuite.Web.ImageGen
             }
             return outImage;
         }
+        public static bool Available()
+        {
+            return LibHeifInfo.HaveDecoder(HeifCompressionFormat.Av1) && LibHeifInfo.HaveDecoder(HeifCompressionFormat.Hevc); 
+        }
     }
 }

--- a/TownSuite.Web.ImageGen/HeifDecoder.cs
+++ b/TownSuite.Web.ImageGen/HeifDecoder.cs
@@ -13,12 +13,12 @@ namespace TownSuite.Web.ImageGen
             stream.CopyTo(ms);
    
             using var heifContext = new HeifContext(ms.ToArray());
-            using var srcImageHandle = heifContext.GetPrimaryImageHandle();
-            using var srcImage = srcImageHandle.Decode(HeifColorspace.Rgb, HeifChroma.InterleavedRgba32);
+            using HeifImageHandle srcImageHandle = heifContext.GetPrimaryImageHandle();
+            using HeifImage srcImage = srcImageHandle.Decode(HeifColorspace.Rgb, HeifChroma.InterleavedRgba32);
 
             var outImage = new Image<Rgba32>(srcImage.Width, srcImage.Height);
 
-            var planeData = srcImage.GetPlane(HeifChannel.Interleaved);
+            HeifPlaneData planeData = srcImage.GetPlane(HeifChannel.Interleaved);
             IntPtr startPtr = planeData.Scan0;
             int stride = planeData.Stride;
 
@@ -26,7 +26,7 @@ namespace TownSuite.Web.ImageGen
             {
                for (int x = 0; x < srcImage.Width; x++)
                 {
-                   var ptr = startPtr + (y * stride) + (x * 4);
+                   IntPtr ptr = startPtr + (y * stride) + (x * 4);
                    var r = Marshal.ReadByte(ptr);
                    var g = Marshal.ReadByte(ptr + 1);
                    var b = Marshal.ReadByte(ptr + 2);

--- a/TownSuite.Web.ImageGen/HeifEncoder.cs
+++ b/TownSuite.Web.ImageGen/HeifEncoder.cs
@@ -32,9 +32,9 @@ using System.Runtime.InteropServices;
 
 namespace TownSuite.Web.ImageGen
 {
-    internal static class ImageConversion
+    internal static class HeifEncoder
     {
-        public static HeifImage ConvertToHeifImage(Image<Rgba32> image)
+        public static HeifImage ConvertSharpToHeif(Image<Rgba32> image)
         {
             (bool isGrayscale, bool hasTransparency) = AnalyzeImage(image);
             var colorspace = isGrayscale ? HeifColorspace.Monochrome : HeifColorspace.Rgb;

--- a/TownSuite.Web.ImageGen/HeifEncoder.cs
+++ b/TownSuite.Web.ImageGen/HeifEncoder.cs
@@ -84,10 +84,10 @@ namespace TownSuite.Web.ImageGen
             {
                 for (int y = 0; y < accessor.Height; y++)
                 {
-                    var src = accessor.GetRowSpan(y);
+                    Span<Rgba32> src = accessor.GetRowSpan(y);
                     for (int x = 0; x < accessor.Width; x++)
                     {
-                        ref var pixel = ref src[x];
+                        ref Rgba32 pixel = ref src[x];
                         if (!(pixel.R == pixel.G && pixel.G == pixel.B))
                         {
                             isGrayscale = false;
@@ -106,12 +106,12 @@ namespace TownSuite.Web.ImageGen
                                                  HeifImage heifImage,
                                                  bool hasTransparency)
         {
-            var grayPlane = heifImage.GetPlane(HeifChannel.Y);
+            HeifPlaneData grayPlane = heifImage.GetPlane(HeifChannel.Y);
             IntPtr grayStartPtr = grayPlane.Scan0;
             int grayPlaneStride = grayPlane.Stride;
             if (hasTransparency)
             {
-                var alphaPlane = heifImage.GetPlane(HeifChannel.Alpha);
+                HeifPlaneData alphaPlane = heifImage.GetPlane(HeifChannel.Alpha);
                 IntPtr alphaStartPtr = grayPlane.Scan0;
                 int alphaPlaneStride = alphaPlane.Stride;
 
@@ -119,10 +119,10 @@ namespace TownSuite.Web.ImageGen
                 {
                     for (int y = 0; y < accessor.Height; y++)
                     {
-                        var src = accessor.GetRowSpan(y);
+                        Span<Rgba32> src = accessor.GetRowSpan(y);
                         for (int x = 0; x < accessor.Width; x++)
                         {
-                            ref var pixel = ref src[x];
+                            ref Rgba32 pixel = ref src[x];
                             SetAlpha(pixel.A, alphaStartPtr + x + (y * alphaPlaneStride));
                             SetGrayscale(pixel.R, grayStartPtr + x + (y * grayPlaneStride));
                         }
@@ -135,10 +135,10 @@ namespace TownSuite.Web.ImageGen
                 {
                     for (int y = 0; y < accessor.Height; y++)
                     {
-                        var src = accessor.GetRowSpan(y);
+                        Span<Rgba32> src = accessor.GetRowSpan(y);
                         for (int x = 0; x < accessor.Width; x++)
                         {
-                            ref var pixel = ref src[x];
+                            ref Rgba32 pixel = ref src[x];
                             SetGrayscale(pixel.R, grayStartPtr + x + (y * grayPlaneStride));
                         }
                     }
@@ -150,7 +150,7 @@ namespace TownSuite.Web.ImageGen
                                            HeifImage heifImage,
                                            bool hasTransparency)
         {
-            var interleavedData = heifImage.GetPlane(HeifChannel.Interleaved);
+            HeifPlaneData interleavedData = heifImage.GetPlane(HeifChannel.Interleaved);
             IntPtr startPtr = interleavedData.Scan0;
             int srcStride = interleavedData.Stride;
   
@@ -158,10 +158,10 @@ namespace TownSuite.Web.ImageGen
             {
                 for (int y = 0; y < accessor.Height; y++)
                 {
-                    var src = accessor.GetRowSpan(y);
+                    Span<Rgba32> src = accessor.GetRowSpan(y);
                     for (int x = 0; x < accessor.Width; x++)
                     {
-                        ref var pixel = ref src[x];
+                        ref Rgba32 pixel = ref src[x];
                         if (hasTransparency)
                         {
                             SetRgba(pixel.R, pixel.G, pixel.B, pixel.A, startPtr + (x * 4) + (y * srcStride));

--- a/TownSuite.Web.ImageGen/HeifEncoder.cs
+++ b/TownSuite.Web.ImageGen/HeifEncoder.cs
@@ -198,5 +198,9 @@ namespace TownSuite.Web.ImageGen
             Marshal.WriteByte(pixelPtr + 2, B);
             Marshal.WriteByte(pixelPtr + 3, A);
         }
+        public static bool Available()
+        {
+            return LibHeifInfo.HaveEncoder(HeifCompressionFormat.Av1) && LibHeifInfo.HaveEncoder(HeifCompressionFormat.Hevc);
+        }
     }
 }

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -16,7 +16,7 @@ public static class Helper
         string contentType;
         string extension;
         using var ms = new MemoryStream();
-        var imageFormat = ImageFormat.GetFormat(image_format);
+        ImageFormat.Format imageFormat = ImageFormat.GetFormat(image_format);
 
         if (imageFormat == ImageFormat.Format.jpeg)
         {
@@ -42,9 +42,9 @@ public static class Helper
         else if (imageFormat == ImageFormat.Format.avif && HeifEncoder.Available())
         {
             using (var context = new HeifContext())
-            using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
+            using (HeifImage heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
             {
-                var encoder = context.GetEncoder(HeifCompressionFormat.Av1);
+                LibHeifSharp.HeifEncoder encoder = context.GetEncoder(HeifCompressionFormat.Av1);
                 encoder.SetLossyQuality(85);
                 context.EncodeImage(heifImage, encoder);
                 context.WriteToStream(ms);
@@ -55,9 +55,9 @@ public static class Helper
         else if (imageFormat == ImageFormat.Format.heic && HeifEncoder.Available())
         {
             using (var context = new HeifContext())
-            using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
+            using (HeifImage heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
             {
-                var encoder = context.GetEncoder(HeifCompressionFormat.Hevc);
+                LibHeifSharp.HeifEncoder encoder = context.GetEncoder(HeifCompressionFormat.Hevc);
                 encoder.SetLossyQuality(85); 
                 context.EncodeImage(heifImage, encoder);
                 context.WriteToStream(ms);

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -42,7 +42,7 @@ public static class Helper
         else if (string.Equals(image_format, "avif", StringComparison.InvariantCultureIgnoreCase))
         {
             using (var context = new HeifContext())
-            using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>(), premultiplyAlpha: false))
+            using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>()))
             {
                 var encoder = context.GetEncoder(HeifCompressionFormat.Av1);
                 encoder.SetLossyQuality(85);
@@ -55,7 +55,7 @@ public static class Helper
         else if (string.Equals(image_format, "heif", StringComparison.InvariantCultureIgnoreCase))
         {
             using (var context = new HeifContext())
-            using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>(), premultiplyAlpha: false))
+            using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>()))
             {
                 var encoder = context.GetEncoder(HeifCompressionFormat.Hevc);
                 encoder.SetLossyQuality(85); 

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -52,7 +52,7 @@ public static class Helper
             extension = "avif";
             contentType = "image/avif";
         }
-        else if (imageFormat == ImageFormat.Format.avif && HeifEncoder.Available())
+        else if (imageFormat == ImageFormat.Format.heic && HeifEncoder.Available())
         {
             using (var context = new HeifContext())
             using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -16,9 +16,9 @@ public static class Helper
         string contentType;
         string extension;
         using var ms = new MemoryStream();
+        var imageFormat = ImageFormat.GetFormat(image_format);
 
-        if (string.Equals(image_format, "jpg", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(image_format, "jpeg", StringComparison.InvariantCultureIgnoreCase))
+        if (imageFormat == ImageFormat.Format.jpeg)
         {
             await image.SaveAsync(ms, new JpegEncoder()
             {
@@ -27,19 +27,19 @@ public static class Helper
             extension = "jpeg";
             contentType = "image/jpeg";
         }
-        else if (string.Equals(image_format, "webp", StringComparison.InvariantCultureIgnoreCase))
+        else if (imageFormat == ImageFormat.Format.webp)
         {
             await image.SaveAsync(ms, new WebpEncoder());
             extension = "webp";
             contentType = "image/webp";
         }
-        else if (string.Equals(image_format, "gif", StringComparison.InvariantCultureIgnoreCase))
+        else if (imageFormat == ImageFormat.Format.gif)
         {
             await image.SaveAsync(ms, new GifEncoder());
             extension = "gif";
             contentType = "image/gif";
         }
-        else if (string.Equals(image_format, "avif", StringComparison.InvariantCultureIgnoreCase))
+        else if (imageFormat == ImageFormat.Format.avif && HeifEncoder.Available())
         {
             using (var context = new HeifContext())
             using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
@@ -52,8 +52,7 @@ public static class Helper
             extension = "avif";
             contentType = "image/avif";
         }
-        else if (string.Equals(image_format, "heif", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(image_format, "heic", StringComparison.InvariantCultureIgnoreCase))
+        else if (imageFormat == ImageFormat.Format.avif && HeifEncoder.Available())
         {
             using (var context = new HeifContext())
             using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -52,7 +52,8 @@ public static class Helper
             extension = "avif";
             contentType = "image/avif";
         }
-        else if (string.Equals(image_format, "heif", StringComparison.InvariantCultureIgnoreCase))
+        else if (string.Equals(image_format, "heif", StringComparison.InvariantCultureIgnoreCase)
+            || string.Equals(image_format, "heic", StringComparison.InvariantCultureIgnoreCase))
         {
             using (var context = new HeifContext())
             using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>()))

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -45,24 +45,10 @@ public static class Helper
             using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>(), premultiplyAlpha: false))
             {
                 var encoder = context.GetEncoder(HeifCompressionFormat.Av1);
-                encoder.SetLossyQuality(85); // Adjust quality as needed
-
+                encoder.SetLossyQuality(85);
                 context.EncodeImage(heifImage, encoder);
-
-                // Write the HeifImage to a temporary file
-                var tempFilePath = Path.GetRandomFileName();
-                context.WriteToFile(tempFilePath);
-
-                // Read the temporary file into the MemoryStream
-                using (var fileStream = File.OpenRead(tempFilePath))
-                {
-                    await fileStream.CopyToAsync(ms);
-                }
-
-                // Delete the temporary file
-                File.Delete(tempFilePath);
+                context.WriteToStream(ms);
             }
-
             extension = "avif";
             contentType = "image/avif";
         }
@@ -72,25 +58,10 @@ public static class Helper
             using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>(), premultiplyAlpha: false))
             {
                 var encoder = context.GetEncoder(HeifCompressionFormat.Hevc);
-                encoder.SetLossyQuality(85); // Adjust quality as needed
-
+                encoder.SetLossyQuality(85); 
                 context.EncodeImage(heifImage, encoder);
-
-                // Write the HeifImage to a temporary file
-                var tempFilePath = Path.GetRandomFileName();
-                context.WriteToFile(tempFilePath);
-      
-
-                // Read the temporary file into the MemoryStream
-                using (var fileStream = File.OpenRead(tempFilePath))
-                {
-                    await fileStream.CopyToAsync(ms);
-                }
-
-                // Delete the temporary file
-                File.Delete(tempFilePath);
+                context.WriteToStream(ms);
             }
-
             extension = "heif";
             contentType = "image/heif";
         }

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -42,7 +42,7 @@ public static class Helper
         else if (string.Equals(image_format, "avif", StringComparison.InvariantCultureIgnoreCase))
         {
             using (var context = new HeifContext())
-            using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>()))
+            using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
             {
                 var encoder = context.GetEncoder(HeifCompressionFormat.Av1);
                 encoder.SetLossyQuality(85);
@@ -56,7 +56,7 @@ public static class Helper
             || string.Equals(image_format, "heic", StringComparison.InvariantCultureIgnoreCase))
         {
             using (var context = new HeifContext())
-            using (var heifImage = ImageConversion.ConvertToHeifImage(image.CloneAs<Rgba32>()))
+            using (var heifImage = HeifEncoder.ConvertSharpToHeif(image.CloneAs<Rgba32>()))
             {
                 var encoder = context.GetEncoder(HeifCompressionFormat.Hevc);
                 encoder.SetLossyQuality(85); 

--- a/TownSuite.Web.ImageGen/Helper.cs
+++ b/TownSuite.Web.ImageGen/Helper.cs
@@ -63,8 +63,8 @@ public static class Helper
                 context.EncodeImage(heifImage, encoder);
                 context.WriteToStream(ms);
             }
-            extension = "heif";
-            contentType = "image/heif";
+            extension = "heic";
+            contentType = "image/heic";
         }
         else
         {

--- a/TownSuite.Web.ImageGen/ImageConversion.cs
+++ b/TownSuite.Web.ImageGen/ImageConversion.cs
@@ -28,12 +28,13 @@
 using LibHeifSharp;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using System.Runtime.InteropServices;
 
 namespace TownSuite.Web.ImageGen
 {
     internal static class ImageConversion
     {
-        public static HeifImage ConvertToHeifImage(Image<Rgba32> image, bool premultiplyAlpha)
+        public static HeifImage ConvertToHeifImage(Image<Rgba32> image)
         {
             (bool isGrayscale, bool hasTransparency) = AnalyzeImage(image);
             var colorspace = isGrayscale ? HeifColorspace.Monochrome : HeifColorspace.Rgb;
@@ -58,13 +59,12 @@ namespace TownSuite.Web.ImageGen
                     {
                         temp.AddPlane(HeifChannel.Alpha, image.Width, image.Height, 8);
                     }
-                    CopyGrayscale(image, temp, hasTransparency, premultiplyAlpha);
+                    CopyGrayscale(image, temp, hasTransparency);
                 }
                 else
                 {
                     temp.AddPlane(HeifChannel.Interleaved, image.Width, image.Height, 8);
-
-                    CopyRgb(image, temp, hasTransparency, premultiplyAlpha);
+                    CopyRgb(image, temp, hasTransparency);
                 }
                 heifImage = temp;
                 temp = null;
@@ -102,51 +102,29 @@ namespace TownSuite.Web.ImageGen
             return (isGrayscale, hasTransparency);
         }
 
-        private static unsafe void CopyGrayscale(Image<Rgba32> image,
+        private static void CopyGrayscale(Image<Rgba32> image,
                                                  HeifImage heifImage,
-                                                 bool hasTransparency,
-                                                 bool premultiplyAlpha)
+                                                 bool hasTransparency)
         {
             var grayPlane = heifImage.GetPlane(HeifChannel.Y);
-            byte* grayPlaneScan0 = (byte*)grayPlane.Scan0;
+            IntPtr grayStartPtr = grayPlane.Scan0;
             int grayPlaneStride = grayPlane.Stride;
             if (hasTransparency)
             {
                 var alphaPlane = heifImage.GetPlane(HeifChannel.Alpha);
-                byte* alphaPlaneScan0 = (byte*)alphaPlane.Scan0;
+                IntPtr alphaStartPtr = grayPlane.Scan0;
                 int alphaPlaneStride = alphaPlane.Stride;
+
                 image.ProcessPixelRows(accessor =>
                 {
                     for (int y = 0; y < accessor.Height; y++)
                     {
                         var src = accessor.GetRowSpan(y);
-                        byte* dst = grayPlaneScan0 + (y * grayPlaneStride);
-                        byte* dstAlpha = alphaPlaneScan0 + (y * alphaPlaneStride);
                         for (int x = 0; x < accessor.Width; x++)
                         {
                             ref var pixel = ref src[x];
-                            if (premultiplyAlpha)
-                            {
-                                switch (pixel.A)
-                                {
-                                    case 0:
-                                        dst[0] = 0;
-                                        break;
-                                    case 255:
-                                        dst[0] = pixel.R;
-                                        break;
-                                    default:
-                                        dst[0] = (byte)MathF.Round((float)pixel.R * pixel.A / 255f);
-                                        break;
-                                }
-                            }
-                            else
-                            {
-                                dst[0] = pixel.R;
-                            }
-                            dstAlpha[0] = pixel.A;
-                            dst++;
-                            dstAlpha++;
+                            SetAlpha(pixel.A, alphaStartPtr + x + (y * grayPlaneStride));
+                            SetGrayscale(pixel.R, grayStartPtr + x + (y * grayPlaneStride));
                         }
                     }
                 });
@@ -158,89 +136,68 @@ namespace TownSuite.Web.ImageGen
                     for (int y = 0; y < accessor.Height; y++)
                     {
                         var src = accessor.GetRowSpan(y);
-                        byte* dst = grayPlaneScan0 + (y * grayPlaneStride);
                         for (int x = 0; x < accessor.Width; x++)
                         {
                             ref var pixel = ref src[x];
-                            dst[0] = pixel.R;
-                            dst++;
+                            SetGrayscale(pixel.R, grayStartPtr + x + (y * grayPlaneStride));
                         }
                     }
                 });
             }
         }
 
-        private static unsafe void CopyRgb(Image<Rgba32> image,
+        private static void CopyRgb(Image<Rgba32> image,
                                            HeifImage heifImage,
-                                           bool hasTransparency,
-                                           bool premultiplyAlpha)
+                                           bool hasTransparency)
         {
             var interleavedData = heifImage.GetPlane(HeifChannel.Interleaved);
-            byte* srcScan0 = (byte*)interleavedData.Scan0;
+            IntPtr startPtr = interleavedData.Scan0;
             int srcStride = interleavedData.Stride;
-            if (hasTransparency)
+  
+            image.ProcessPixelRows(accessor =>
             {
-                image.ProcessPixelRows(accessor =>
+                for (int y = 0; y < accessor.Height; y++)
                 {
-                    for (int y = 0; y < accessor.Height; y++)
+                    var src = accessor.GetRowSpan(y);
+                    for (int x = 0; x < accessor.Width; x++)
                     {
-                        var src = accessor.GetRowSpan(y);
-                        byte* dst = srcScan0 + (y * srcStride);
-                        for (int x = 0; x < accessor.Width; x++)
+                        ref var pixel = ref src[x];
+                        if (hasTransparency)
                         {
-                            ref var pixel = ref src[x];
-                            if (premultiplyAlpha)
-                            {
-                                switch (pixel.A)
-                                {
-                                    case 0:
-                                        dst[0] = 0;
-                                        dst[1] = 0;
-                                        dst[2] = 0;
-                                        break;
-                                    case 255:
-                                        dst[0] = pixel.R;
-                                        dst[1] = pixel.G;
-                                        dst[2] = pixel.B;
-                                        break;
-                                    default:
-                                        dst[0] = (byte)MathF.Round((float)pixel.R * pixel.A / 255f);
-                                        dst[1] = (byte)MathF.Round((float)pixel.G * pixel.A / 255f);
-                                        dst[2] = (byte)MathF.Round((float)pixel.B * pixel.A / 255f);
-                                        break;
-                                }
-                            }
-                            else
-                            {
-                                dst[0] = pixel.R;
-                                dst[1] = pixel.G;
-                                dst[2] = pixel.B;
-                            }
-                            dst[3] = pixel.A;
-                            dst += 4;
+                            SetRgba(pixel.R, pixel.G, pixel.B, pixel.A, startPtr + (x * 4) + (y * srcStride));
+                        } else
+                        {
+                            SetRgb(pixel.R, pixel.G, pixel.B, startPtr + (x * 3) + (y * srcStride));
                         }
                     }
-                });
-            }
-            else
-            {
-                image.ProcessPixelRows(accessor =>
-                {
-                    for (int y = 0; y < accessor.Height; y++)
-                    {
-                        var src = accessor.GetRowSpan(y);
-                        byte* dst = srcScan0 + (y * srcStride);
-                        for (int x = 0; x < accessor.Width; x++)
-                        {
-                            ref var pixel = ref src[x];
-                            dst[0] = pixel.R;
-                            dst[1] = pixel.G;
-                            dst[2] = pixel.B;
-                            dst += 3;
-                        }
-                    }
-                });
-            }
+                }
+            });
         }
+
+        private static void SetGrayscale(byte R, IntPtr pixelPtr)
+        {
+            Marshal.WriteByte(pixelPtr, R);
+        }
+
+        private static void SetAlpha(byte A, IntPtr pixelPtr)
+        {
+            Marshal.WriteByte(pixelPtr, A);
+        }
+
+        private static void SetRgb(byte R, byte G, byte B, IntPtr pixelPtr)
+        {
+            Marshal.WriteByte(pixelPtr, R);
+            Marshal.WriteByte(pixelPtr + 1, G);
+            Marshal.WriteByte(pixelPtr + 2, B);
+        }
+
+        public static void SetRgba(byte R, byte G, byte B, byte A, IntPtr pixelPtr)
+        {
+            Marshal.WriteByte(pixelPtr, R);
+            Marshal.WriteByte(pixelPtr + 1, G);
+            Marshal.WriteByte(pixelPtr + 2, B);
+            Marshal.WriteByte(pixelPtr + 3, A);
+        }
+
     }
 }

--- a/TownSuite.Web.ImageGen/ImageConversion.cs
+++ b/TownSuite.Web.ImageGen/ImageConversion.cs
@@ -29,12 +29,10 @@ using LibHeifSharp;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
-
 namespace TownSuite.Web.ImageGen
 {
     internal static class ImageConversion
     {
-
         public static HeifImage ConvertToHeifImage(Image<Rgba32> image, bool premultiplyAlpha)
         {
             (bool isGrayscale, bool hasTransparency) = AnalyzeImage(image);
@@ -195,7 +193,6 @@ namespace TownSuite.Web.ImageGen
                 });
             }
         }
-
 
         private static unsafe void CopyRgb(Image<Rgba32> image,
                                            HeifImage heifImage,

--- a/TownSuite.Web.ImageGen/ImageConversion.cs
+++ b/TownSuite.Web.ImageGen/ImageConversion.cs
@@ -123,7 +123,7 @@ namespace TownSuite.Web.ImageGen
                         for (int x = 0; x < accessor.Width; x++)
                         {
                             ref var pixel = ref src[x];
-                            SetAlpha(pixel.A, alphaStartPtr + x + (y * grayPlaneStride));
+                            SetAlpha(pixel.A, alphaStartPtr + x + (y * alphaPlaneStride));
                             SetGrayscale(pixel.R, grayStartPtr + x + (y * grayPlaneStride));
                         }
                     }

--- a/TownSuite.Web.ImageGen/ImageConversion.cs
+++ b/TownSuite.Web.ImageGen/ImageConversion.cs
@@ -1,0 +1,281 @@
+﻿/*
+ * This file is part of heif-enc, an example encoder application for libheif-sharp
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020, 2021, 2022, 2023 Nicholas Hayes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+using LibHeifSharp;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+
+namespace TownSuite.Web.ImageGen
+{
+    internal static class ImageConversion
+    {
+
+        public static HeifImage ConvertToHeifImage(Image<Rgba32> image, bool premultiplyAlpha)
+        {
+            (bool isGrayscale, bool hasTransparency) = AnalyzeImage(image);
+
+            var colorspace = isGrayscale ? HeifColorspace.Monochrome : HeifColorspace.Rgb;
+            HeifChroma chroma;
+
+            if (colorspace == HeifColorspace.Monochrome)
+            {
+                chroma = HeifChroma.Monochrome;
+            }
+            else
+            {
+                chroma = hasTransparency ? HeifChroma.InterleavedRgba32 : HeifChroma.InterleavedRgb24;
+            }
+
+            HeifImage heifImage = null;
+            HeifImage temp = null;
+
+            try
+            {
+                temp = new HeifImage(image.Width, image.Height, colorspace, chroma);
+
+                if (colorspace == HeifColorspace.Monochrome)
+                {
+                    temp.AddPlane(HeifChannel.Y, image.Width, image.Height, 8);
+
+                    if (hasTransparency)
+                    {
+                        temp.AddPlane(HeifChannel.Alpha, image.Width, image.Height, 8);
+                    }
+
+                    CopyGrayscale(image, temp, hasTransparency, premultiplyAlpha);
+                }
+                else
+                {
+                    temp.AddPlane(HeifChannel.Interleaved, image.Width, image.Height, 8);
+
+                    CopyRgb(image, temp, hasTransparency, premultiplyAlpha);
+                }
+
+                heifImage = temp;
+                temp = null;
+            }
+            finally
+            {
+                temp?.Dispose();
+            }
+
+            return heifImage;
+        }
+
+        private static (bool isGrayscale, bool hasTransparency) AnalyzeImage(Image<Rgba32> image)
+        {
+            bool isGrayscale = true;
+            bool hasTransparency = false;
+
+            image.ProcessPixelRows(accessor =>
+            {
+                for (int y = 0; y < accessor.Height; y++)
+                {
+                    var src = accessor.GetRowSpan(y);
+
+                    for (int x = 0; x < accessor.Width; x++)
+                    {
+                        ref var pixel = ref src[x];
+
+                        if (!(pixel.R == pixel.G && pixel.G == pixel.B))
+                        {
+                            isGrayscale = false;
+                        }
+
+                        if (pixel.A < 255)
+                        {
+                            hasTransparency = true;
+                        }
+                    }
+                }
+            });
+
+            return (isGrayscale, hasTransparency);
+        }
+
+        private static unsafe void CopyGrayscale(Image<Rgba32> image,
+                                                 HeifImage heifImage,
+                                                 bool hasTransparency,
+                                                 bool premultiplyAlpha)
+        {
+            var grayPlane = heifImage.GetPlane(HeifChannel.Y);
+
+            byte* grayPlaneScan0 = (byte*)grayPlane.Scan0;
+            int grayPlaneStride = grayPlane.Stride;
+
+            if (hasTransparency)
+            {
+                var alphaPlane = heifImage.GetPlane(HeifChannel.Alpha);
+
+                byte* alphaPlaneScan0 = (byte*)alphaPlane.Scan0;
+                int alphaPlaneStride = alphaPlane.Stride;
+
+                image.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        var src = accessor.GetRowSpan(y);
+                        byte* dst = grayPlaneScan0 + (y * grayPlaneStride);
+                        byte* dstAlpha = alphaPlaneScan0 + (y * alphaPlaneStride);
+
+                        for (int x = 0; x < accessor.Width; x++)
+                        {
+                            ref var pixel = ref src[x];
+
+                            if (premultiplyAlpha)
+                            {
+                                switch (pixel.A)
+                                {
+                                    case 0:
+                                        dst[0] = 0;
+                                        break;
+                                    case 255:
+                                        dst[0] = pixel.R;
+                                        break;
+                                    default:
+                                        dst[0] = (byte)MathF.Round((float)pixel.R * pixel.A / 255f);
+                                        break;
+                                }
+                            }
+                            else
+                            {
+                                dst[0] = pixel.R;
+                            }
+                            dstAlpha[0] = pixel.A;
+
+                            dst++;
+                            dstAlpha++;
+                        }
+                    }
+                });
+            }
+            else
+            {
+                image.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        var src = accessor.GetRowSpan(y);
+                        byte* dst = grayPlaneScan0 + (y * grayPlaneStride);
+
+                        for (int x = 0; x < accessor.Width; x++)
+                        {
+                            ref var pixel = ref src[x];
+
+                            dst[0] = pixel.R;
+
+                            dst++;
+                        }
+                    }
+                });
+            }
+        }
+
+
+        private static unsafe void CopyRgb(Image<Rgba32> image,
+                                           HeifImage heifImage,
+                                           bool hasTransparency,
+                                           bool premultiplyAlpha)
+        {
+            var interleavedData = heifImage.GetPlane(HeifChannel.Interleaved);
+
+            byte* srcScan0 = (byte*)interleavedData.Scan0;
+            int srcStride = interleavedData.Stride;
+
+            if (hasTransparency)
+            {
+                image.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        var src = accessor.GetRowSpan(y);
+                        byte* dst = srcScan0 + (y * srcStride);
+
+                        for (int x = 0; x < accessor.Width; x++)
+                        {
+                            ref var pixel = ref src[x];
+
+                            if (premultiplyAlpha)
+                            {
+                                switch (pixel.A)
+                                {
+                                    case 0:
+                                        dst[0] = 0;
+                                        dst[1] = 0;
+                                        dst[2] = 0;
+                                        break;
+                                    case 255:
+                                        dst[0] = pixel.R;
+                                        dst[1] = pixel.G;
+                                        dst[2] = pixel.B;
+                                        break;
+                                    default:
+                                        dst[0] = (byte)MathF.Round((float)pixel.R * pixel.A / 255f);
+                                        dst[1] = (byte)MathF.Round((float)pixel.G * pixel.A / 255f);
+                                        dst[2] = (byte)MathF.Round((float)pixel.B * pixel.A / 255f);
+                                        break;
+                                }
+                            }
+                            else
+                            {
+                                dst[0] = pixel.R;
+                                dst[1] = pixel.G;
+                                dst[2] = pixel.B;
+                            }
+                            dst[3] = pixel.A;
+
+                            dst += 4;
+                        }
+                    }
+                });
+            }
+            else
+            {
+                image.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        var src = accessor.GetRowSpan(y);
+                        byte* dst = srcScan0 + (y * srcStride);
+
+                        for (int x = 0; x < accessor.Width; x++)
+                        {
+                            ref var pixel = ref src[x];
+
+                            dst[0] = pixel.R;
+                            dst[1] = pixel.G;
+                            dst[2] = pixel.B;
+
+                            dst += 3;
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/TownSuite.Web.ImageGen/ImageConversion.cs
+++ b/TownSuite.Web.ImageGen/ImageConversion.cs
@@ -198,6 +198,5 @@ namespace TownSuite.Web.ImageGen
             Marshal.WriteByte(pixelPtr + 2, B);
             Marshal.WriteByte(pixelPtr + 3, A);
         }
-
     }
 }

--- a/TownSuite.Web.ImageGen/ImageFormat.cs
+++ b/TownSuite.Web.ImageGen/ImageFormat.cs
@@ -18,7 +18,6 @@
         { 
             return string.Equals(TrimFormat(formatStr), type.ToString(), StringComparison.InvariantCultureIgnoreCase);
         }
-
         public static Format GetFormat(string formatStr)
         {
             try { return (Format)Enum.Parse(typeof(Format), TrimFormat(formatStr), true); }
@@ -35,6 +34,5 @@
             if (formatStr.Contains("svg")) formatStr = "svg";
             return formatStr;
         }
-
     }
 }

--- a/TownSuite.Web.ImageGen/ImageFormat.cs
+++ b/TownSuite.Web.ImageGen/ImageFormat.cs
@@ -1,0 +1,43 @@
+﻿namespace TownSuite.Web.ImageGen
+{
+    public class ImageFormat
+    {
+        public enum Format
+        {
+            jpeg,
+            png,
+            gif,
+            bmp,
+            tiff,
+            webp,
+            svg,
+            heic,
+            avif
+        }
+        public static bool IsFormat(string formatStr, Format type)
+        {
+            if (formatStr.StartsWith("image/"))
+            {
+                formatStr = formatStr[6..];
+            }
+            if (formatStr.Contains("jpg")) formatStr = "jpeg";
+            if (formatStr == "heif") formatStr = "heic";
+            if (formatStr.Contains("svg")) formatStr = "svg";
+            return string.Equals(formatStr, type.ToString(), StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public static Format GetFormat(string formatStr)
+        {
+            if (formatStr.StartsWith("image/"))
+            {
+                formatStr = formatStr[6..];
+            }
+            if (formatStr.Contains("jpg")) formatStr = "jpeg";
+            if (formatStr == "heif") formatStr = "heic";
+            if (formatStr.Contains("svg")) formatStr = "svg";
+            return (Format)Enum.Parse(typeof(Format), formatStr, true);
+            
+        }
+
+    }
+}

--- a/TownSuite.Web.ImageGen/ImageFormat.cs
+++ b/TownSuite.Web.ImageGen/ImageFormat.cs
@@ -15,19 +15,17 @@
             avif
         }
         public static bool IsFormat(string formatStr, Format type)
-        {
-            if (formatStr.StartsWith("image/"))
-            {
-                formatStr = formatStr[6..];
-            }
-            if (formatStr.Contains("jpg")) formatStr = "jpeg";
-            if (formatStr == "heif") formatStr = "heic";
-            if (formatStr.Contains("svg")) formatStr = "svg";
-            return string.Equals(formatStr, type.ToString(), StringComparison.InvariantCultureIgnoreCase);
+        { 
+            return string.Equals(TrimFormat(formatStr), type.ToString(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static Format GetFormat(string formatStr)
         {
+            try { return (Format)Enum.Parse(typeof(Format), TrimFormat(formatStr), true); }
+            catch { return Format.png; }  
+        }
+        private static string TrimFormat(string formatStr)
+        {
             if (formatStr.StartsWith("image/"))
             {
                 formatStr = formatStr[6..];
@@ -35,8 +33,8 @@
             if (formatStr.Contains("jpg")) formatStr = "jpeg";
             if (formatStr == "heif") formatStr = "heic";
             if (formatStr.Contains("svg")) formatStr = "svg";
-            try { return (Format)Enum.Parse(typeof(Format), formatStr, true); }
-            catch { return Format.png; }  
+            return formatStr;
         }
+
     }
 }

--- a/TownSuite.Web.ImageGen/ImageFormat.cs
+++ b/TownSuite.Web.ImageGen/ImageFormat.cs
@@ -35,7 +35,8 @@
             if (formatStr.Contains("jpg")) formatStr = "jpeg";
             if (formatStr == "heif") formatStr = "heic";
             if (formatStr.Contains("svg")) formatStr = "svg";
-            return (Format)Enum.Parse(typeof(Format), formatStr, true); 
+            try { return (Format)Enum.Parse(typeof(Format), formatStr, true); }
+            catch { return Format.png; }  
         }
     }
 }

--- a/TownSuite.Web.ImageGen/ImageFormat.cs
+++ b/TownSuite.Web.ImageGen/ImageFormat.cs
@@ -35,9 +35,7 @@
             if (formatStr.Contains("jpg")) formatStr = "jpeg";
             if (formatStr == "heif") formatStr = "heic";
             if (formatStr.Contains("svg")) formatStr = "svg";
-            return (Format)Enum.Parse(typeof(Format), formatStr, true);
-            
+            return (Format)Enum.Parse(typeof(Format), formatStr, true); 
         }
-
     }
 }

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -22,7 +22,7 @@ public class ImageProxyRepo : IImageRepository
 
     public async Task<(byte[] imageData, ImageMetaData metadata)> Get(RequestMetaData request)
     {
-        var proxyRequest = request as ImageProxyRequestMetaData;
+        var proxyRequest = request as ImageProxyRequestMetaData ?? throw new ArgumentException("RequestMetaData is not of type ImageProxyRequestMetaData", nameof(request));
         var result = await _downloader.Download(proxyRequest.ImageSrcUrl);
         await using var downloadStream = result.S;
         if (ImageFormat.IsFormat(result.ContentType, ImageFormat.Format.svg))

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -35,8 +35,6 @@ public class ImageProxyRepo : IImageRepository
                 "image/svg+xml", request.Path);
             return (svg, mdSvg);
         }
-        // Check image type. If AVIF or HEIF convert to png, and write to stream.
-        // Should need no other adjustments to support proxying AVIF and HEIF.
 
         var img = await Image.LoadAsync(downloadStream);
 

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -1,9 +1,4 @@
-using SixLabors.Fonts;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 namespace TownSuite.Web.ImageGen;

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -35,7 +35,9 @@ public class ImageProxyRepo : IImageRepository
                 "image/svg+xml", request.Path);
             return (svg, mdSvg);
         }
-        
+        // Check image type. If AVIF or HEIF convert to png, and write to stream.
+        // Should need no other adjustments to support proxying AVIF and HEIF.
+
         var img = await Image.LoadAsync(downloadStream);
 
         if (proxyRequest.WidthChangeRequested && proxyRequest.HeightChangeRequested

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -57,7 +57,7 @@ public class ImageProxyRepo : IImageRepository
             img.Mutate(x => x
                 .Resize(0, proxyRequest.Height));
         }
-        
+
         var img2 = await Helper.BinaryAsBytes(img, proxyRequest.ImageFormat);
         var md = new ImageMetaData(DateTime.UtcNow, TimeSpan.FromMinutes(_settings.HttpCacheControlMaxAgeInMinutes), img2.image.Length,
             $"{request.Id}.{img2.fileExt}",

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -35,7 +35,7 @@ public class ImageProxyRepo : IImageRepository
                 "image/svg+xml", request.Path);
             return (svg, mdSvg);
         }
-
+        
         var img = await Image.LoadAsync(downloadStream);
 
         if (proxyRequest.WidthChangeRequested && proxyRequest.HeightChangeRequested
@@ -57,7 +57,7 @@ public class ImageProxyRepo : IImageRepository
             img.Mutate(x => x
                 .Resize(0, proxyRequest.Height));
         }
-
+        
         var img2 = await Helper.BinaryAsBytes(img, proxyRequest.ImageFormat);
         var md = new ImageMetaData(DateTime.UtcNow, TimeSpan.FromMinutes(_settings.HttpCacheControlMaxAgeInMinutes), img2.image.Length,
             $"{request.Id}.{img2.fileExt}",

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -25,7 +25,7 @@ public class ImageProxyRepo : IImageRepository
         var proxyRequest = request as ImageProxyRequestMetaData;
         var result = await _downloader.Download(proxyRequest.ImageSrcUrl);
         await using var downloadStream = result.S;
-        if (string.Equals(result.ContentType, "image/svg+xml", StringComparison.InvariantCultureIgnoreCase))
+        if (ImageFormat.IsFormat(result.ContentType, ImageFormat.Format.svg))
         {
             using var ms = new MemoryStream();
             await downloadStream.CopyToAsync(ms);
@@ -38,8 +38,8 @@ public class ImageProxyRepo : IImageRepository
         
         Image img;
 
-        if (string.Equals(result.ContentType, "image/avif", StringComparison.InvariantCultureIgnoreCase)
-                       || string.Equals(result.ContentType, "image/heic", StringComparison.InvariantCultureIgnoreCase))
+        if (ImageFormat.IsFormat(result.ContentType, ImageFormat.Format.avif)
+            || ImageFormat.IsFormat(result.ContentType, ImageFormat.Format.heic))
         {
             img = HeifDecoder.ConvertHeifToSharp(downloadStream);
         }

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -36,7 +36,17 @@ public class ImageProxyRepo : IImageRepository
             return (svg, mdSvg);
         }
         
-        var img = await Image.LoadAsync(downloadStream);
+        Image img;
+
+        if (string.Equals(result.ContentType, "image/avif", StringComparison.InvariantCultureIgnoreCase)
+                       || string.Equals(result.ContentType, "image/heic", StringComparison.InvariantCultureIgnoreCase))
+        {
+            img = HeifDecoder.ConvertHeifToSharp(downloadStream);
+        }
+        else
+        {
+            img = await Image.LoadAsync(downloadStream);
+        }
 
         if (proxyRequest.WidthChangeRequested && proxyRequest.HeightChangeRequested
             && ResizeRequestIsSmallerOrEqualToOrignalSize(proxyRequest, img))

--- a/TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj
+++ b/TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj
@@ -7,10 +7,12 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <RootNamespace>TownSuite.Web.ImageGen</RootNamespace>
         <UserSecretsId>de2702d9-c67c-4d6d-8c11-5862a6057efe</UserSecretsId>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Jdenticon-net" Version="3.1.2" />
+      <PackageReference Include="LibHeifSharp" Version="3.1.0" />
       <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
       <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
     </ItemGroup>

--- a/TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj
+++ b/TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj
@@ -7,7 +7,6 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <RootNamespace>TownSuite.Web.ImageGen</RootNamespace>
         <UserSecretsId>de2702d9-c67c-4d6d-8c11-5862a6057efe</UserSecretsId>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/libheif-windows-build.ps1
+++ b/libheif-windows-build.ps1
@@ -11,16 +11,16 @@ else {
     New-Item "libheif-build" -ItemType Directory
 }
 
-git clone -q --depth 1 https://github.com/microsoft/vcpkg libheif-build
+git clone -q --depth 1 "https://github.com/microsoft/vcpkg" libheif-build
 
 Invoke-Expression -Command ".\libheif-build\bootstrap-vcpkg.bat"
 
 .\libheif-build\vcpkg install aom:x64-windows libde265:x64-windows x265:x64-windows libheif:x64-windows
 
-Rename-Item -Path .\libheif-build\installed\x64-windows\bin\heif.dll -NewName "libheif.dll"
+Rename-Item -Path ".\libheif-build\installed\x64-windows\bin\heif.dll" -NewName "libheif.dll"
 
-Copy-Item -Path .\libheif-build\installed\x64-windows\bin\*.dll -Destination .\TownSuite.Web.ImageGen\bin\Debug\net6.0
+Copy-Item -Path ".\libheif-build\installed\x64-windows\bin\*.dll" -Destination ".\TownSuite.Web.ImageGen\bin\Debug\net6.0"
 
-Copy-Item -Path .\libheif-build\installed\x64-windows\bin\*.dll -Destination .\TownSuite.Web.ImageGen.Tests\bin\Debug\net6.0
+Copy-Item -Path ".\libheif-build\installed\x64-windows\bin\*.dll" -Destination ".\TownSuite.Web.ImageGen.Tests\bin\Debug\net6.0"
 
 Remove-Item "libheif-build" -Recurse -Force

--- a/libheif-windows-build.ps1
+++ b/libheif-windows-build.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+$CURRENTPATH=$pwd.Path
+
+# Must install powershell:  https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.2
+
+if (Test-Path "libheif-build") {
+    Remove-Item "libheif-build" -Recurse -Force
+}
+else {
+    New-Item "libheif-build" -ItemType Directory
+}
+
+git clone -q --depth 1 https://github.com/microsoft/vcpkg libheif-build
+
+Invoke-Expression -Command ".\libheif-build\bootstrap-vcpkg.bat"
+
+.\libheif-build\vcpkg install aom:x64-windows libde265:x64-windows x265:x64-windows libheif:x64-windows
+
+Rename-Item -Path .\libheif-build\installed\x64-windows\bin\heif.dll -NewName "libheif.dll"
+
+Copy-Item -Path .\libheif-build\installed\x64-windows\bin\*.dll -Destination .\TownSuite.Web.ImageGen\bin\Debug\net6.0
+
+Copy-Item -Path .\libheif-build\installed\x64-windows\bin\*.dll -Destination .\TownSuite.Web.ImageGen.Tests\bin\Debug\net6.0
+
+Remove-Item "libheif-build" -Recurse -Force

--- a/libheif-windows-build.ps1
+++ b/libheif-windows-build.ps1
@@ -13,9 +13,9 @@ else {
 
 git clone -q --depth 1 "https://github.com/microsoft/vcpkg" libheif-build
 
-Invoke-Expression -Command ".\libheif-build\bootstrap-vcpkg.bat"
+Start-Process -FilePath ".\libheif-build\bootstrap-vcpkg.bat" -ArgumentList "-disableMetrics" -Wait -NoNewWindow
 
-.\libheif-build\vcpkg install aom:x64-windows libde265:x64-windows x265:x64-windows libheif:x64-windows
+Start-Process -FilePath ".\libheif-build\vcpkg.exe" -ArgumentList "install aom:x64-windows libde265:x64-windows x265:x64-windows libheif:x64-windows" -Wait -NoNewWindow 
 
 Rename-Item -Path ".\libheif-build\installed\x64-windows\bin\heif.dll" -NewName "libheif.dll"
 


### PR DESCRIPTION
# Description

Adds AVIF and HEIC support using [Libheif-sharp](https://github.com/0xC0000054/libheif-sharp). See #8


## Encoding
The user now has the ability to specify 'avif' and 'heic' as imgformat properties.

For example: 
``` /placeholder/{thehash}?imgformat=avif ```
``` /avatar/{thehash}?imgformat=heic ``` 
``` /proxy/{thehash}?imgformat=avif ```
#### Approach
My approach was to continue to use ImageSharp for the transformations and use LibHeifSharp to encode image as AVIF or HEIC if the user requested it. This simplifies the solution as we already have a robust transformation pipeline implemented using ImageSharp. 

## Decoding
The ```/proxy/``` route can now accept and properly decode avif and heic. 
The following formats are now accepted as proxy targets: 
PNG, TIFF, JPG, PBM, WEBP, TGA, GIF, BMP, AVIF, and HEIC.

#### Approach
My approach was similar to encoding. I detect if the downloaded image is avif/heic and if so, convert it to ImageSharp format using Libheif-sharp and use that pipeline to transform the images as usual. 

# Docker

> if libheif-sharp does not embed libheif, modify the [dockerfile](https://github.com/TownSuite/TownSuite.Web.ImageGen/blob/main/TownSuite.Web.ImageGen/Dockerfile) to include libheif

Libheif-sharp doesn't embed libheif so I added another build stage responsible for building libheif. Libheif has some required and some optional dependencies. 

[x265](https://github.com/videolan/x265) is used to encode HEIC
[libde265](https://www.libde265.org/) Is used to decode HEIC
[aom](https://aomedia.googlesource.com/aom/) Is used to encode and decode AVIF


x265 and de265 is able to be installed using ```apk add``` but the version of aom installed from ```apk add``` doesn't work with libheif. Aom and libheif are both built from source using make. Only the required ```.so``` files are copied to the final layer.

# Caveats in Development
Libheif-sharp requires some DLL files to function properly on Windows. The DLLs are not required to use the original functionality of PNG, JPG, GIF, and WEBP.
The [Libheif-sharp](https://github.com/0xC0000054/libheif-sharp) project has instructions for building the DLLs [here](https://0xc0000054.github.io/libheif-sharp/libheif_windows_build_vcpkg.html).

Place the generated DLLs in the following two folders```~\TownSuite.Web.ImageGen\bin\Debug\net6.0``` ```~\TownSuite.Web.ImageGen.Tests\bin\Debug\net6.0```
![image](https://github.com/TownSuite/TownSuite.Web.ImageGen/assets/37007232/f2183a97-b05b-45e8-bd3a-4085d2bf9ed8)

***note*** You may need to install ```'Desktop devlopment with C++'``` in Visual Studio to build these images. (You may be able to get away with just installing ```'C++ CMake tools for Windows'``` as vcpkg technically just needs vcvarsall.bat)

# Results 
Running the following command for all of our supported output types:
```curl "localhost:5239/avatar/L13231231?imgformat={format}&w=2000" --output ./avatar.{format}```
| Format | Size (KB) | Time (ms)
|:------:|-----------|------------|
| AVIF   | 11        | 70
| WEBP   | 24        | 130
| PNG    | 28        |  26
| GIF    | 32        |  31
| HEIC   | 41        |  93
| JPG    | 121       |  125