### PR TITLE
security enhancements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,5 +9,13 @@
     <Company>TownSuite Municipal Software Inc.</Company>
     <Product>TownSuite Image Proxy and Placeholders</Product>
     <Copyright>Copyright © TownSuite Municipal Software Inc. 2026</Copyright>
+
+    <!-- Supply-chain security: audit NuGet dependencies (direct + transitive) against
+         the advisory feed during restore, and fail the build on any finding.
+         NU1901=low, NU1902=moderate, NU1903=high, NU1904=critical. -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Readme.md
+++ b/Readme.md
@@ -25,8 +25,10 @@ The default image format is png.
 
 # Appsettings.json
 
-1. "CacheFolder": "wwwroot/cache",
-    * The base folder to store cached images.
+1. "CacheFolder": "cache",
+    * The base folder to store cached images. Keep this **outside** of `wwwroot` so cached
+      content is not served directly as static files (it is served only through the
+      application endpoints, with the correct headers).
 2. "CacheBackgroundCleanupTimerSeconds": 300,
     * How many seconds are between background cleanup runs.
 3. "CacheMaxLifeTimeMinutes": 1440,
@@ -37,8 +39,20 @@ The default image format is png.
     * The max width that can be requested for an image resize.
 6. "MaxHeight": 2000,
     * The max height that can be requested for an image resize.
-7. "UserAgent": "TownSuiteImageGen/1.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:107.0) Gecko/20100101 Firefox/107.0"
+7. "MaxDownloadSizeInMiB": 55,
+    * The maximum size of a remote response the image proxy will download. Protects
+      against memory-exhaustion / open-proxy abuse.
+8. "ProxyTimeoutSeconds": 30,
+    * Timeout for a single proxied download.
+9. "MaxSourceImagePixels": 100000000,
+    * The maximum number of pixels (width × height) allowed in a *source* image before it
+      is decoded. Protects against decompression / pixel bombs. Set to 0 to disable.
+10. "UserAgent": "TownSuiteImageGen/1.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:107.0) Gecko/20100101 Firefox/107.0"
     * The user agent that will be used in the image proxy.
+
+The image proxy also enforces SSRF protections (only http/https, no redirects, and
+private/loopback/link-local/cloud-metadata addresses are blocked) and per-client rate
+limiting (default 60 requests/minute/IP).
 
 
 # Identicon example

--- a/TownSuite.Web.ImageGen.Tests/HeifDecodeTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/HeifDecodeTest.cs
@@ -29,4 +29,24 @@ public class HeifDecodeTest
             Assert.That(image.Width, Is.EqualTo(1));
         });
     }
+
+    private static bool HeifAvailable()
+    {
+        // HeifDecoder.Available() throws (rather than returning false) when the native
+        // libheif library can't be loaded, so guard it for machines without the codec.
+        try { return HeifDecoder.Available(); }
+        catch { return false; }
+    }
+
+    [TestCase("avif"), TestCase("heic")]
+    public async Task ConvertHeifToSharp_ThrowsWhenSourceExceedsMaxPixels(string imageformat)
+    {
+        Assume.That(HeifAvailable(), "libheif decoder not available on this machine");
+
+        var imageName = $"assets/{imageformat}_test.{imageformat}";
+        using var ms = new MemoryStream(await File.ReadAllBytesAsync(imageName));
+
+        // The test assets are 200x200 = 40,000 px; a cap of 1 must be rejected before decode.
+        Assert.Throws<InvalidOperationException>(() => HeifDecoder.ConvertHeifToSharp(ms, maxPixels: 1));
+    }
 }

--- a/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/ImageProxyRepoTest.cs
@@ -99,6 +99,33 @@ public class ImageProxyRepoTest
         Assert.That(newImage.Width, Is.EqualTo(200));
     }
     
+    [Test]
+    public void ExceedingMaxSourceImagePixels_ThrowsBeforeDecode()
+    {
+        // facility.jpg is 200x91 = 18,200 px; a cap of 100 must be rejected.
+        var downloader = new DownloaderFake("image/jpeg");
+        var repo = new ImageProxyRepo(downloader, new Settings()
+        {
+            HttpCacheControlMaxAgeInMinutes = 5,
+            MaxSourceImagePixels = 100
+        });
+        var request = new ImageProxyRequestMetaData();
+        var query = CreateContext(50, 50, "png");
+
+        request.GetRequestMetaData(new Settings()
+            {
+                CacheFolder = "cache/folder/",
+                MaxHeight = 1000,
+                MaxWidth = 1000
+            },
+            query.query,
+            query.rawQuery,
+            "/proxy/assets%2Ffacility.jpg",
+            "test_output");
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await repo.Get(request));
+    }
+
     private (QueryCollection query, string rawQuery) CreateContext(int h, int w,string imgformat)
     {
         var queries = new Dictionary<string, StringValues>

--- a/TownSuite.Web.ImageGen.Tests/SsrfGuardTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/SsrfGuardTest.cs
@@ -56,6 +56,7 @@ public class SsrfGuardTest
     [TestCase("1.1.1.1", false)]             // public
     [TestCase("93.184.216.34", false)]       // public (example.com)
     // IPv6
+    [TestCase("::", true)]                   // unspecified (IPv6 equivalent of 0.0.0.0)
     [TestCase("::1", true)]                  // loopback
     [TestCase("fe80::1", true)]              // link-local
     [TestCase("fc00::1", true)]              // unique local (fc00::/7)

--- a/TownSuite.Web.ImageGen.Tests/SsrfGuardTest.cs
+++ b/TownSuite.Web.ImageGen.Tests/SsrfGuardTest.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using TownSuite.Web.ImageGen;
+
+namespace TownSuite.Web.ImageGen.Tests;
+
+[TestFixture]
+public class SsrfGuardTest
+{
+    [TestCase("http://example.com/a.png")]
+    [TestCase("https://example.com/a.png")]
+    [TestCase("HTTP://Example.com")]
+    [TestCase("HTTPS://example.com:8443/x")]
+    public void ValidateUrl_AllowsHttpAndHttps(string url)
+    {
+        Assert.DoesNotThrow(() => SsrfGuard.ValidateUrl(url));
+    }
+
+    [TestCase("ftp://example.com/a.png")]
+    [TestCase("file:///etc/passwd")]
+    [TestCase("gopher://example.com")]
+    [TestCase("data:text/plain,hello")]
+    [TestCase("/relative/path")]
+    [TestCase("not a url")]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void ValidateUrl_RejectsNonHttp(string url)
+    {
+        Assert.Throws<ArgumentException>(() => SsrfGuard.ValidateUrl(url));
+    }
+
+    [Test]
+    public void ValidateUrl_RejectsNull()
+    {
+        Assert.Throws<ArgumentException>(() => SsrfGuard.ValidateUrl(null!));
+    }
+
+    // IPv4
+    [TestCase("127.0.0.1", true)]            // loopback
+    [TestCase("127.5.5.5", true)]            // loopback /8
+    [TestCase("10.0.0.1", true)]             // private
+    [TestCase("10.255.255.255", true)]       // private
+    [TestCase("172.16.0.1", true)]           // private /12 lower bound
+    [TestCase("172.31.255.255", true)]       // private /12 upper bound
+    [TestCase("172.15.0.1", false)]          // just below /12
+    [TestCase("172.32.0.1", false)]          // just above /12
+    [TestCase("192.168.1.1", true)]          // private
+    [TestCase("169.254.169.254", true)]      // link-local / cloud metadata
+    [TestCase("100.64.0.1", true)]           // CGNAT lower bound
+    [TestCase("100.127.255.255", true)]      // CGNAT upper bound
+    [TestCase("100.63.255.255", false)]      // just below CGNAT
+    [TestCase("100.128.0.1", false)]         // just above CGNAT
+    [TestCase("0.0.0.0", true)]              // "this network"
+    [TestCase("224.0.0.1", true)]            // multicast
+    [TestCase("240.0.0.1", true)]            // reserved
+    [TestCase("8.8.8.8", false)]             // public
+    [TestCase("1.1.1.1", false)]             // public
+    [TestCase("93.184.216.34", false)]       // public (example.com)
+    // IPv6
+    [TestCase("::1", true)]                  // loopback
+    [TestCase("fe80::1", true)]              // link-local
+    [TestCase("fc00::1", true)]              // unique local (fc00::/7)
+    [TestCase("fd00::1", true)]              // unique local
+    [TestCase("ff02::1", true)]              // multicast
+    [TestCase("::ffff:10.0.0.1", true)]      // IPv4-mapped private
+    [TestCase("::ffff:169.254.169.254", true)] // IPv4-mapped metadata
+    [TestCase("::ffff:8.8.8.8", false)]      // IPv4-mapped public
+    [TestCase("2606:4700:4700::1111", false)] // public (Cloudflare)
+    public void IsBlocked_ClassifiesAddresses(string ip, bool expected)
+    {
+        var address = IPAddress.Parse(ip);
+        Assert.That(SsrfGuard.IsBlocked(address), Is.EqualTo(expected));
+    }
+}

--- a/TownSuite.Web.ImageGen/Dockerfile
+++ b/TownSuite.Web.ImageGen/Dockerfile
@@ -5,11 +5,23 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 8443
 
+# =============================================================================
+# Native image codecs (aom / libheif / libde265 / x265) decode UNTRUSTED bytes
+# from the image proxy. They are a memory-safety attack surface, so keep them
+# patched:
+#   * aom / libheif are pinned to explicit tags below — bump them when upstream
+#     ships security releases. Track advisories:
+#       - libheif:  https://github.com/strukturag/libheif/releases
+#       - aom:      https://aomedia.googlesource.com/aom / CVE feeds (e.g. CVE-2025-8879)
+#   * libde265 / x265 come from Alpine (apk) and are patched by rebuilding on an
+#     updated base image — rebuild this image regularly so apk pulls fixes.
+# Last reviewed / bumped: 2026-06-19.
+# =============================================================================
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS libheif-build
 # add nasm and pkgconfig for assembler and pkg-config detection
 RUN apk add --no-cache build-base git cmake yasm nasm pkgconfig perl libde265 libde265-dev x265 x265-dev
 WORKDIR /tmp
-RUN git clone --branch v3.13.1 --depth 1 --single-branch https://aomedia.googlesource.com/aom
+RUN git clone --branch v3.14.1 --depth 1 --single-branch https://aomedia.googlesource.com/aom
 WORKDIR /tmp/aom
 # set POSIX / large-file defines so fseeko/ftello are visible on musl
 RUN mkdir -p build && cd build && \
@@ -18,7 +30,7 @@ RUN mkdir -p build && cd build && \
           -DCMAKE_CXX_FLAGS="-D_XOPEN_SOURCE=700 -D_FILE_OFFSET_BITS=64" \
           .. && make -j$(nproc) && make install
 WORKDIR /app
-RUN git clone --branch v1.21.2 --depth 1 --single-branch https://github.com/strukturag/libheif.git
+RUN git clone --branch v1.23.0 --depth 1 --single-branch https://github.com/strukturag/libheif.git
 WORKDIR /app/libheif
 RUN mkdir build
 WORKDIR /app/libheif/build
@@ -38,6 +50,13 @@ COPY ["TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj", "TownSuite.Web.Ima
 COPY ["Directory.Packages.props", "Directory.Packages.props"]
 COPY ["Directory.Build.props", "Directory.Build.props"]
 RUN dotnet restore "TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj"
+# Supply-chain gate: fail the build if any direct or transitive NuGet package has a
+# known security advisory. NuGetAudit in Directory.Build.props also enforces this during
+# restore; this step surfaces the finding explicitly in CI logs.
+RUN dotnet list "TownSuite.Web.ImageGen/TownSuite.Web.ImageGen.csproj" package --vulnerable --include-transitive 2>&1 | tee /tmp/vuln.txt && \
+    if grep -q "has the following vulnerable packages" /tmp/vuln.txt; then \
+      echo "ERROR: vulnerable NuGet packages detected (see list above)." >&2; exit 1; \
+    fi
 COPY . .
 WORKDIR "/src/TownSuite.Web.ImageGen"
 RUN dotnet build "TownSuite.Web.ImageGen.csproj" -c Release -o /app/build
@@ -54,7 +73,7 @@ COPY --from=libheif-build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 COPY --from=libheif-build /usr/lib/libnuma.so.1 /usr/lib/libnuma.so.1
 WORKDIR /app
 COPY --from=publish /app/publish .
-RUN mkdir -p /app/wwwroot/cache && \
-    chown -R $APP_UID /app/wwwroot/cache
+RUN mkdir -p /app/cache && \
+    chown -R $APP_UID /app/cache
 USER $APP_UID
 ENTRYPOINT ["dotnet", "TownSuite.Web.ImageGen.dll"]

--- a/TownSuite.Web.ImageGen/HeifDecoder.cs
+++ b/TownSuite.Web.ImageGen/HeifDecoder.cs
@@ -7,7 +7,7 @@ namespace TownSuite.Web.ImageGen
 {
     public static class HeifDecoder
     {
-        public static Image<Rgba32> ConvertHeifToSharp(Stream stream)
+        public static Image<Rgba32> ConvertHeifToSharp(Stream stream, long maxPixels = 0)
         {
             if (!Available())
                 throw new Exception("HeifDecoder is not available");
@@ -15,9 +15,14 @@ namespace TownSuite.Web.ImageGen
                 throw new ArgumentException("Invalid stream", stream.GetType().Name);
             if (stream.Length < 1)
                 return new Image<Rgba32>(1, 1);
-            
+
             using var heifContext = new HeifContext(stream);
             using HeifImageHandle srcImageHandle = heifContext.GetPrimaryImageHandle();
+
+            // Reject decompression/pixel bombs before decoding into a full RGBA buffer.
+            if (maxPixels > 0 && (long)srcImageHandle.Width * srcImageHandle.Height > maxPixels)
+                throw new InvalidOperationException("Source image exceeds the maximum allowed pixel dimensions.");
+
             using HeifImage srcImage = srcImageHandle.Decode(HeifColorspace.Rgb, HeifChroma.InterleavedRgba32);
 
             var outImage = new Image<Rgba32>(srcImage.Width, srcImage.Height);

--- a/TownSuite.Web.ImageGen/ImageDownloader.cs
+++ b/TownSuite.Web.ImageGen/ImageDownloader.cs
@@ -22,13 +22,44 @@ public class ImageDownloader : IImageDownloader
         var client = _clientFactory.CreateClient("imageproxy");
         using var request = new HttpRequestMessage(HttpMethod.Get, srcUrl);
         request.Headers.Add("User-Agent", _settings.UserAgent);
-        
-        using var response = await client.SendAsync(request);
+
+        long maxBytes = (_settings.MaxDownloadSizeInMiB > 0 ? _settings.MaxDownloadSizeInMiB : 25) * 1024L * 1024L;
+
+        // ResponseHeadersRead so we can reject oversized responses without buffering them.
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
         response.EnsureSuccessStatusCode();
+
+        // Reject early if the server advertises a size over the limit...
+        if (response.Content.Headers.ContentLength is long advertised && advertised > maxBytes)
+        {
+            throw new InvalidOperationException("Remote image exceeds the maximum allowed download size.");
+        }
+
         var ms = new MemoryStream();
-        await response.Content.CopyToAsync(ms);
-        await ms.FlushAsync();
+        // ...and enforce the cap while streaming, in case Content-Length is absent or lies
+        // (e.g. chunked transfer encoding).
+        await using (var src = await response.Content.ReadAsStreamAsync())
+        {
+            await CopyWithLimitAsync(src, ms, maxBytes);
+        }
         ms.Position = 0;
         return (ms, response.Content.Headers?.ContentType?.ToString() ?? "");
+    }
+
+    private static async Task CopyWithLimitAsync(Stream source, Stream destination, long maxBytes)
+    {
+        var buffer = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await source.ReadAsync(buffer)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                throw new InvalidOperationException("Remote image exceeds the maximum allowed download size.");
+            }
+
+            await destination.WriteAsync(buffer.AsMemory(0, read));
+        }
     }
 }

--- a/TownSuite.Web.ImageGen/ImageDownloader.cs
+++ b/TownSuite.Web.ImageGen/ImageDownloader.cs
@@ -15,7 +15,11 @@ public class ImageDownloader : IImageDownloader
 
     public async Task<(Stream S, string ContentType)> Download(string srcUrl)
     {
-        var client = _clientFactory.CreateClient();
+        // Reject non-http(s) schemes before doing anything else. The connection-time
+        // SSRF checks (private/loopback/link-local blocking, no redirects) are enforced
+        // by the "imageproxy" named client configured in Program.cs.
+        SsrfGuard.ValidateUrl(srcUrl);
+        var client = _clientFactory.CreateClient("imageproxy");
         using var request = new HttpRequestMessage(HttpMethod.Get, srcUrl);
         request.Headers.Add("User-Agent", _settings.UserAgent);
         

--- a/TownSuite.Web.ImageGen/ImageProxyRepo.cs
+++ b/TownSuite.Web.ImageGen/ImageProxyRepo.cs
@@ -36,10 +36,21 @@ public class ImageProxyRepo : IImageRepository
         if (ImageFormat.IsFormat(result.ContentType, ImageFormat.Format.avif)
             || ImageFormat.IsFormat(result.ContentType, ImageFormat.Format.heic))
         {
-            img = HeifDecoder.ConvertHeifToSharp(downloadStream);
+            img = HeifDecoder.ConvertHeifToSharp(downloadStream, _settings.MaxSourceImagePixels);
         }
         else
         {
+            // Check the source dimensions cheaply (without decoding pixels) and reject
+            // decompression/pixel bombs before allocating the full image.
+            var info = await Image.IdentifyAsync(downloadStream);
+            if (downloadStream.CanSeek)
+            {
+                downloadStream.Position = 0;
+            }
+            if (info is not null)
+            {
+                EnsureWithinPixelLimit(info.Width, info.Height);
+            }
             img = await Image.LoadAsync(downloadStream);
         }
 
@@ -79,5 +90,14 @@ public class ImageProxyRepo : IImageRepository
     {
         return proxyRequest.Height <= img.Height && proxyRequest.Width <= img.Width;
     }
-    
+
+    private void EnsureWithinPixelLimit(int width, int height)
+    {
+        long maxPixels = _settings.MaxSourceImagePixels;
+        if (maxPixels > 0 && (long)width * height > maxPixels)
+        {
+            throw new InvalidOperationException("Source image exceeds the maximum allowed pixel dimensions.");
+        }
+    }
+
 }

--- a/TownSuite.Web.ImageGen/Program.cs
+++ b/TownSuite.Web.ImageGen/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Security.Cryptography;
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.Extensions.Primitives;
 using TownSuite.Web.ImageGen;
@@ -15,6 +16,11 @@ builder.Services.AddHttpClient("imageproxy")
     {
         AllowAutoRedirect = false,
         ConnectCallback = SsrfGuard.ConnectCallback
+    })
+    .ConfigureHttpClient((sp, client) =>
+    {
+        var s = sp.GetRequiredService<Settings>();
+        client.Timeout = TimeSpan.FromSeconds(s.ProxyTimeoutSeconds > 0 ? s.ProxyTimeoutSeconds : 30);
     });
 builder.Services.AddScoped<IImageDownloader, ImageDownloader>();
 builder.Services.AddSingleton<Settings>(s => new Settings()
@@ -26,7 +32,29 @@ builder.Services.AddSingleton<Settings>(s => new Settings()
     CacheSizeLimitInMiB = builder.Configuration.GetValue<int>("CacheSizeLimitInMiB"),
     HttpCacheControlMaxAgeInMinutes = builder.Configuration.GetValue<int>("HttpCacheControlMaxAgeInMinutes"),
     MaxWidth = builder.Configuration.GetValue<int>("MaxWidth"),
-    UserAgent = builder.Configuration.GetValue<string>("UserAgent")
+    UserAgent = builder.Configuration.GetValue<string>("UserAgent"),
+    MaxDownloadSizeInMiB = builder.Configuration.GetValue<int>("MaxDownloadSizeInMiB"),
+    ProxyTimeoutSeconds = builder.Configuration.GetValue<int>("ProxyTimeoutSeconds"),
+    MaxSourceImagePixels = builder.Configuration.GetValue<long>("MaxSourceImagePixels")
+});
+
+// Rate limiting (DoS / abuse protection). Partitioned by client IP with a fixed window.
+// NOTE: behind a reverse proxy / k8s ingress, enable ForwardedHeaders middleware with a
+// trusted-proxy configuration so RemoteIpAddress reflects the real client rather than the
+// proxy; otherwise all traffic shares one partition.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+    {
+        var key = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 60,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0
+        });
+    });
 });
 
 builder.Services.AddHostedService<BackgroundWorkerService>();
@@ -46,11 +74,30 @@ else
             context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
             context.Response.ContentType = "text/plain";
 
-            var exceptionHandlerPathFeature = context.Features.Get<IExceptionHandlerPathFeature>();
-            await context.Response.WriteAsync(exceptionHandlerPathFeature?.Error.Message ?? "");
+            // Do NOT echo the exception message to the client: it can leak internal
+            // details (cache paths, resolved internal IPs from SSRF checks, downstream
+            // hostnames) and acts as a recon oracle. Log the real error server-side and
+            // return a generic message instead.
+            var feature = context.Features.Get<IExceptionHandlerPathFeature>();
+            if (feature?.Error is not null)
+            {
+                var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+                logger.LogError(feature.Error, "Unhandled error processing {Path}", feature.Path);
+            }
+
+            await context.Response.WriteAsync("An error occurred while processing the request.");
         });
     });
 }
+
+// Defense-in-depth: prevent MIME-type sniffing on every response.
+app.Use(async (context, next) =>
+{
+    context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    await next();
+});
+
+app.UseRateLimiter();
 
 app.MapGet("/avatar/{name}", async (HttpContext ctx, Settings config) =>
 {
@@ -91,12 +138,28 @@ app.Run();
 
 async Task WriteOutput(HttpContext ctx, ImageMetaData metadata)
 {
-    ctx.Response.Headers.Add("Content-Type", metadata.ContentType);
-    ctx.Response.Headers.Add("Expires",  DateTime.UtcNow.Add(metadata.Expires).ToString("R"));
-    ctx.Response.Headers.Add("Cache-Control", $"max-age={metadata.Expires.TotalSeconds}");
-    ctx.Response.Headers.Add("Content-Length", metadata.ContentLength.ToString());
-    ctx.Response.Headers.Add("Last-Modified", metadata.LastModifiedUtc.ToUniversalTime().ToString("R"));
-    ctx.Response.Headers.Add("Content-Disposition", $"inline; filename=\"{metadata.Filename}\"");
-    await using var fs = new FileStream(metadata.FullFilePath, FileMode.Open);
+    var headers = ctx.Response.Headers;
+    headers["Content-Type"] = metadata.ContentType;
+    headers["Expires"] = DateTime.UtcNow.Add(metadata.Expires).ToString("R");
+    headers["Cache-Control"] = $"max-age={metadata.Expires.TotalSeconds}";
+    headers["Content-Length"] = metadata.ContentLength.ToString();
+    headers["Last-Modified"] = metadata.LastModifiedUtc.ToUniversalTime().ToString("R");
+
+    // SVG can carry active content (scripts / event handlers). Force a download and
+    // sandbox it so it is never rendered inline in the service's origin (stored-XSS
+    // prevention). Other image types are safe to display inline.
+    bool isSvg = metadata.ContentType is not null &&
+                 metadata.ContentType.Contains("svg", StringComparison.OrdinalIgnoreCase);
+    if (isSvg)
+    {
+        headers["Content-Disposition"] = $"attachment; filename=\"{metadata.Filename}\"";
+        headers["Content-Security-Policy"] = "default-src 'none'; sandbox";
+    }
+    else
+    {
+        headers["Content-Disposition"] = $"inline; filename=\"{metadata.Filename}\"";
+    }
+
+    await using var fs = new FileStream(metadata.FullFilePath, FileMode.Open, FileAccess.Read);
     await fs.CopyToAsync(ctx.Response.Body);
 }

--- a/TownSuite.Web.ImageGen/Program.cs
+++ b/TownSuite.Web.ImageGen/Program.cs
@@ -15,6 +15,10 @@ builder.Services.AddHttpClient("imageproxy")
     .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
     {
         AllowAutoRedirect = false,
+        // Disable any ambient/system HTTP proxy. Otherwise requests would be tunneled to
+        // the proxy and the connect-time IP checks would validate the proxy's address
+        // instead of the real destination, bypassing the SSRF guard.
+        UseProxy = false,
         ConnectCallback = SsrfGuard.ConnectCallback
     })
     .ConfigureHttpClient((sp, client) =>
@@ -133,7 +137,9 @@ app.MapGet("/proxy/{name}", async (HttpContext ctx, IImageDownloader downloader,
 });
 
 app.UseStaticFiles();
-app.MapHealthChecks("/healthz");
+// Exempt health checks from rate limiting so liveness/readiness probes are never
+// throttled (a 429 to the kubelet would trigger spurious restarts).
+app.MapHealthChecks("/healthz").DisableRateLimiting();
 app.Run();
 
 async Task WriteOutput(HttpContext ctx, ImageMetaData metadata)

--- a/TownSuite.Web.ImageGen/Program.cs
+++ b/TownSuite.Web.ImageGen/Program.cs
@@ -8,6 +8,14 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
 builder.Services.AddHttpClient();
+// SSRF-hardened client used by the image proxy: no redirect following and a
+// connect-time guard that blocks private/loopback/link-local/metadata addresses.
+builder.Services.AddHttpClient("imageproxy")
+    .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+    {
+        AllowAutoRedirect = false,
+        ConnectCallback = SsrfGuard.ConnectCallback
+    });
 builder.Services.AddScoped<IImageDownloader, ImageDownloader>();
 builder.Services.AddSingleton<Settings>(s => new Settings()
 {

--- a/TownSuite.Web.ImageGen/Program.cs
+++ b/TownSuite.Web.ImageGen/Program.cs
@@ -65,6 +65,15 @@ builder.Services.AddHostedService<BackgroundWorkerService>();
 
 var app = builder.Build();
 
+// Ensure the cache directory exists at startup so the background cleanup service and the
+// cache writer don't error on first run — important for local / non-Docker deployments
+// where the configured path (e.g. relative "cache") may not exist yet.
+var startupSettings = app.Services.GetRequiredService<Settings>();
+if (!string.IsNullOrWhiteSpace(startupSettings.CacheFolder))
+{
+    Directory.CreateDirectory(startupSettings.CacheFolder);
+}
+
 if (builder.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
@@ -77,6 +86,9 @@ else
         {
             context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
             context.Response.ContentType = "text/plain";
+            // UseExceptionHandler clears headers set by downstream middleware, so re-apply
+            // the nosniff header here to keep it on error responses too.
+            context.Response.Headers["X-Content-Type-Options"] = "nosniff";
 
             // Do NOT echo the exception message to the client: it can leak internal
             // details (cache paths, resolved internal IPs from SSRF checks, downstream
@@ -147,7 +159,7 @@ async Task WriteOutput(HttpContext ctx, ImageMetaData metadata)
     var headers = ctx.Response.Headers;
     headers["Content-Type"] = metadata.ContentType;
     headers["Expires"] = DateTime.UtcNow.Add(metadata.Expires).ToString("R");
-    headers["Cache-Control"] = $"max-age={metadata.Expires.TotalSeconds}";
+    headers["Cache-Control"] = $"max-age={(long)metadata.Expires.TotalSeconds}";
     headers["Content-Length"] = metadata.ContentLength.ToString();
     headers["Last-Modified"] = metadata.LastModifiedUtc.ToUniversalTime().ToString("R");
 

--- a/TownSuite.Web.ImageGen/RequestMetaData.cs
+++ b/TownSuite.Web.ImageGen/RequestMetaData.cs
@@ -58,6 +58,14 @@ public class RequestMetaData
             image_format = "png";
         }
 
+        // Normalize the requested format to a known, safe enum value BEFORE it is
+        // ever used to build a filesystem path. The raw "imgformat" query value is
+        // attacker-controlled and was previously interpolated straight into the cache
+        // path, allowing path-traversal (e.g. imgformat=png/../../../../etc/passwd).
+        // GetFormat returns one of the fixed ImageFormat.Format names (falling back to
+        // png), so it can never contain '/', '\' or ".." separators.
+        string safeFormat = global::TownSuite.Web.ImageGen.ImageFormat.GetFormat(image_format).ToString();
+
         string path;
         if (size == 0)
         {
@@ -66,13 +74,13 @@ public class RequestMetaData
                 throw new Exception($"Max allowable width is {maxWidth} and max allowable height is {maxHeight}");
             }
 
-            path = System.IO.Path.Combine(cacheFolder, cacheSubFolder, $"{id}_{width}_{height}.{image_format}");
+            path = BuildCachePath(cacheFolder, cacheSubFolder, $"{id}_{width}_{height}.{safeFormat}");
 
             this.Height = height;
             this.Width = width;
             this.Path = path;
             this.Id = id;
-            this.ImageFormat = image_format;
+            this.ImageFormat = safeFormat;
 
             return this;
         }
@@ -82,16 +90,40 @@ public class RequestMetaData
             throw new Exception($"Max allowable width is {maxWidth} and max allowable height is {maxHeight}");
         }
 
-        path = System.IO.Path.Combine(cacheFolder, cacheSubFolder, $"{id}_{size}_{size}.{image_format}");
+        path = BuildCachePath(cacheFolder, cacheSubFolder, $"{id}_{size}_{size}.{safeFormat}");
 
         this.Height = size;
         this.Width = size;
         this.Path = path;
         this.Id = id;
-        this.ImageFormat = image_format;
+        this.ImageFormat = safeFormat;
 
 
         return this;
+    }
+
+    /// <summary>
+    /// Combines the cache folder, sub-folder and file name, then verifies the resolved
+    /// path stays inside the configured cache folder. Defense-in-depth against path
+    /// traversal in any path segment (the file name is already restricted to a hash plus
+    /// a normalized format, but this guards against future regressions and misconfig).
+    /// </summary>
+    static string BuildCachePath(string cacheFolder, string cacheSubFolder, string fileName)
+    {
+        string cacheRoot = System.IO.Path.GetFullPath(cacheFolder);
+        string fullPath = System.IO.Path.GetFullPath(
+            System.IO.Path.Combine(cacheRoot, cacheSubFolder, fileName));
+
+        string prefix = cacheRoot.EndsWith(System.IO.Path.DirectorySeparatorChar)
+            ? cacheRoot
+            : cacheRoot + System.IO.Path.DirectorySeparatorChar;
+
+        if (!fullPath.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Resolved cache path escapes the cache directory.");
+        }
+
+        return fullPath;
     }
 
     static string Hash(string nonHashedString)

--- a/TownSuite.Web.ImageGen/RequestMetaData.cs
+++ b/TownSuite.Web.ImageGen/RequestMetaData.cs
@@ -114,11 +114,13 @@ public class RequestMetaData
         string fullPath = System.IO.Path.GetFullPath(
             System.IO.Path.Combine(cacheRoot, cacheSubFolder, fileName));
 
-        string prefix = cacheRoot.EndsWith(System.IO.Path.DirectorySeparatorChar)
-            ? cacheRoot
-            : cacheRoot + System.IO.Path.DirectorySeparatorChar;
-
-        if (!fullPath.StartsWith(prefix, StringComparison.Ordinal))
+        // Use GetRelativePath rather than a string prefix check: it applies the platform's
+        // path-comparison rules (case-insensitive drive letters on Windows) and correctly
+        // detects escapes via "..", an absolute path, or a different volume.
+        string relative = System.IO.Path.GetRelativePath(cacheRoot, fullPath);
+        if (relative == ".."
+            || relative.StartsWith(".." + System.IO.Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            || System.IO.Path.IsPathRooted(relative))
         {
             throw new ArgumentException("Resolved cache path escapes the cache directory.");
         }

--- a/TownSuite.Web.ImageGen/RequestMetaData.cs
+++ b/TownSuite.Web.ImageGen/RequestMetaData.cs
@@ -128,9 +128,12 @@ public class RequestMetaData
 
     static string Hash(string nonHashedString)
     {
-        using var md5 = MD5.Create();
+        // SHA-256 (not MD5): MD5 is collision-broken, which for a cache key means an
+        // attacker could craft two distinct inputs that map to the same cache file and
+        // poison/confuse cached content. This value is only a cache key/filename, so a
+        // plain (non-salted) cryptographic hash is appropriate.
         byte[] data = System.Text.Encoding.UTF8.GetBytes(nonHashedString);
-        byte[] retVal = md5.ComputeHash(data);
-        return BitConverter.ToString(retVal);
+        byte[] retVal = SHA256.HashData(data);
+        return Convert.ToHexString(retVal);
     }
 }

--- a/TownSuite.Web.ImageGen/Settings.cs
+++ b/TownSuite.Web.ImageGen/Settings.cs
@@ -10,4 +10,13 @@ public class Settings
     public int MaxWidth { get; init; }
     public int MaxHeight { get; init; }
     public string UserAgent { get; init; }
+
+    // Image-proxy resource limits (DoS / open-proxy protection).
+    // Maximum size of a remote response the proxy will download, in MiB.
+    public int MaxDownloadSizeInMiB { get; init; }
+    // Timeout for a single proxied download, in seconds.
+    public int ProxyTimeoutSeconds { get; init; }
+    // Maximum number of pixels (width * height) allowed in a *source* image before
+    // decoding. Guards against decompression/pixel bombs that decode to huge buffers.
+    public long MaxSourceImagePixels { get; init; }
 }

--- a/TownSuite.Web.ImageGen/SsrfGuard.cs
+++ b/TownSuite.Web.ImageGen/SsrfGuard.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 
@@ -66,12 +67,45 @@ public static class SsrfGuard
             }
         }
 
-        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        // Create a socket that can reach the validated address(es). Prefer an IPv6
+        // dual-mode socket (handles AAAA records and, via IPv4-mapped addresses, A records);
+        // fall back to IPv4 when the OS has no IPv6 support. A plain
+        // new Socket(SocketType, ProtocolType) would fail for IPv6-only destinations.
+        Socket socket;
+        IPAddress[] connectAddresses;
+        if (Socket.OSSupportsIPv6)
+        {
+            socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp)
+            {
+                DualMode = true,
+                NoDelay = true
+            };
+            connectAddresses = addresses
+                .Select(a => a.AddressFamily == AddressFamily.InterNetwork ? a.MapToIPv6() : a)
+                .ToArray();
+        }
+        else
+        {
+            socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+            {
+                NoDelay = true
+            };
+            connectAddresses = addresses
+                .Where(a => a.AddressFamily == AddressFamily.InterNetwork)
+                .ToArray();
+
+            if (connectAddresses.Length == 0)
+            {
+                socket.Dispose();
+                throw new IOException($"Host '{host}' has no reachable IPv4 address.");
+            }
+        }
+
         try
         {
             // Connect to the validated address(es) directly so the destination cannot
             // change between validation and the actual connection (DNS rebinding).
-            await socket.ConnectAsync(addresses, port, cancellationToken);
+            await socket.ConnectAsync(connectAddresses, port, cancellationToken);
             return new NetworkStream(socket, ownsSocket: true);
         }
         catch
@@ -94,6 +128,13 @@ public static class SsrfGuard
         }
 
         if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        // IPv6 unspecified address (:: / IPAddress.IPv6Any) — the IPv6 equivalent of
+        // 0.0.0.0; must be rejected (the IPv4 0.0.0.0/8 case is handled below).
+        if (address.Equals(IPAddress.IPv6Any))
         {
             return true;
         }

--- a/TownSuite.Web.ImageGen/SsrfGuard.cs
+++ b/TownSuite.Web.ImageGen/SsrfGuard.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace TownSuite.Web.ImageGen;
+
+/// <summary>
+/// Server-Side Request Forgery (SSRF) protection for the image proxy.
+///
+/// The proxy fetches an arbitrary, attacker-supplied URL. Without controls this can be
+/// abused to reach cloud metadata endpoints (e.g. 169.254.169.254), loopback, and
+/// internal/cluster-only services, and to scan the internal network.
+///
+/// This guard enforces two layers:
+///   1. <see cref="ValidateUrl"/> rejects non-http(s) schemes up front.
+///   2. <see cref="ConnectCallback"/> is wired into the HttpClient's SocketsHttpHandler.
+///      It resolves the host, rejects any disallowed (private/loopback/link-local/etc.)
+///      address, and connects to a validated IP. Validating at connect time (rather than
+///      only on the original URL string) defeats DNS rebinding and redirect-based bypass.
+/// Redirect following is disabled on the handler as additional defense in depth.
+/// </summary>
+public static class SsrfGuard
+{
+    public static void ValidateUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)
+            || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            throw new ArgumentException("Image source URL is not a valid absolute URL.");
+        }
+
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new ArgumentException("Only http and https image source URLs are allowed.");
+        }
+    }
+
+    public static async ValueTask<Stream> ConnectCallback(
+        SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    {
+        string host = context.DnsEndPoint.Host;
+        int port = context.DnsEndPoint.Port;
+
+        IPAddress[] addresses;
+        if (IPAddress.TryParse(host, out var literal))
+        {
+            addresses = new[] { literal };
+        }
+        else
+        {
+            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken);
+        }
+
+        if (addresses.Length == 0)
+        {
+            throw new IOException($"Could not resolve host '{host}'.");
+        }
+
+        // Reject the whole request if ANY resolved address is disallowed. This is strict
+        // on purpose: it prevents a host that resolves to both a public and a private
+        // address from being used to reach the private one.
+        foreach (var address in addresses)
+        {
+            if (IsBlocked(address))
+            {
+                throw new IOException($"Refusing to connect to disallowed address {address}.");
+            }
+        }
+
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            // Connect to the validated address(es) directly so the destination cannot
+            // change between validation and the actual connection (DNS rebinding).
+            await socket.ConnectAsync(addresses, port, cancellationToken);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Returns true for addresses the proxy must never connect to: loopback, private,
+    /// link-local (incl. cloud metadata 169.254.0.0/16), CGNAT, multicast/reserved,
+    /// unique-local IPv6, etc.
+    /// </summary>
+    public static bool IsBlocked(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
+        if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        byte[] bytes = address.GetAddressBytes();
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            // 0.0.0.0/8 (this network / unspecified)
+            if (bytes[0] == 0) return true;
+            // 10.0.0.0/8 (private)
+            if (bytes[0] == 10) return true;
+            // 100.64.0.0/10 (carrier-grade NAT)
+            if (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) return true;
+            // 127.0.0.0/8 (loopback; also covered by IsLoopback)
+            if (bytes[0] == 127) return true;
+            // 169.254.0.0/16 (link-local, incl. cloud metadata)
+            if (bytes[0] == 169 && bytes[1] == 254) return true;
+            // 172.16.0.0/12 (private)
+            if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) return true;
+            // 192.168.0.0/16 (private)
+            if (bytes[0] == 192 && bytes[1] == 168) return true;
+            // 224.0.0.0/4 (multicast) and 240.0.0.0/4 (reserved/broadcast)
+            if (bytes[0] >= 224) return true;
+
+            return false;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal || address.IsIPv6Multicast)
+            {
+                return true;
+            }
+            // Unique local addresses fc00::/7
+            if ((bytes[0] & 0xFE) == 0xFC) return true;
+
+            return false;
+        }
+
+        // Unknown address family: block by default.
+        return true;
+    }
+}

--- a/TownSuite.Web.ImageGen/appsettings.json
+++ b/TownSuite.Web.ImageGen/appsettings.json
@@ -6,12 +6,15 @@
     }
   },
   "AllowedHosts": "*",
-  "CacheFolder": "wwwroot/cache",
+  "CacheFolder": "cache",
   "CacheBackgroundCleanupTimerSeconds": 300,
   "CacheMaxLifeTimeMinutes": 1440,
   "CacheSizeLimitInMiB": 10000,
   "HttpCacheControlMaxAgeInMinutes": 43200,
   "MaxWidth": 2000,
   "MaxHeight": 2000,
+  "MaxDownloadSizeInMiB": 55,
+  "ProxyTimeoutSeconds": 30,
+  "MaxSourceImagePixels": 100000000,
   "UserAgent": "TownSuiteImageGen/1.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:107.0) Gecko/20100101 Firefox/107.0"
 }

--- a/k8s/linode-k8s-example.yaml
+++ b/k8s/linode-k8s-example.yaml
@@ -45,10 +45,45 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 10
+        # Resource limits cap the blast radius of the proxy's DoS surface (large
+        # downloads + image decoding) so one pod cannot exhaust the node. Size the
+        # memory limit relative to the app's MaxSourceImagePixels setting (a decoded
+        # RGBA image uses roughly pixels * 4 bytes) times expected concurrency;
+        # over-limit requests get the pod OOMKilled rather than starving the node.
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "256Mi"
+          limits:
+            cpu: "2"
+            memory: "1Gi"
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # The root filesystem is read-only; the app needs writable scratch space for
+        # its image cache and for temp files.
+        - name: cache
+          mountPath: /app/cache
+        - name: tmp
+          mountPath: /tmp
       securityContext:
         runAsNonRoot: true
+        # 1654 is the non-root UID/GID baked into the .NET (APP_UID) base image.
+        # fsGroup makes the emptyDir volumes writable by that user.
+        runAsUser: 1654
+        runAsGroup: 1654
+        fsGroup: 1654
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       #imagePullSecrets:
       #- name: [Your Secrets Name]
 


### PR DESCRIPTION
This pull request introduces several important security and robustness improvements to the image proxy service. The main changes include enforcing supply-chain security for dependencies, adding multiple layers of protection against denial-of-service (DoS) and server-side request forgery (SSRF) attacks, and improving cache and image handling safety. The service now also implements per-client rate limiting and strengthens response header security.

**Supply-chain and Dependency Security:**

* Enforces auditing of all NuGet dependencies (direct and transitive) for known vulnerabilities during build and restore, failing the build if any are found. This is configured in `Directory.Build.props` and surfaced explicitly in the Docker build process. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR12-R19) [[2]](diffhunk://#diff-d647708604415c7fc0be829b1b127b99586b596e658a3d05a62e29c7f386144eR53-R59)
* Updates native codec dependencies in the Dockerfile (`aom` and `libheif`) to the latest security-patched versions, with documentation on tracking advisories. [[1]](diffhunk://#diff-d647708604415c7fc0be829b1b127b99586b596e658a3d05a62e29c7f386144eR8-R24) [[2]](diffhunk://#diff-d647708604415c7fc0be829b1b127b99586b596e658a3d05a62e29c7f386144eL21-R33)

**Image Proxy and DoS/Abuse Protections:**

* Adds per-client IP rate limiting (default 60 requests/minute) using ASP.NET's rate limiter, with guidance for correct deployment behind proxies.
* Enforces strict SSRF protections for proxied downloads: only allows HTTP/HTTPS, blocks redirects, and blocks private/loopback/link-local/cloud-metadata addresses. [[1]](diffhunk://#diff-958ed1b37f2d1bd11fa0a848499668c0068974f33a40a7c37bcac84c9d77b55fR12-R24) [[2]](diffhunk://#diff-ed9ac5b5554bddad36d64a3ec81e4b9cc3ad7b8ed90f57cb8cd005993ac475b5L18-R64)
* Adds settings and enforcement for maximum remote image download size and proxy timeout, preventing memory exhaustion and resource abuse. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L40-R56) [[2]](diffhunk://#diff-958ed1b37f2d1bd11fa0a848499668c0068974f33a40a7c37bcac84c9d77b55fL21-R57) [[3]](diffhunk://#diff-ed9ac5b5554bddad36d64a3ec81e4b9cc3ad7b8ed90f57cb8cd005993ac475b5L18-R64)
* Rejects "decompression bombs" by enforcing a maximum allowed pixel count on source images, both for HEIF/AVIF and other formats, before full decode. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L40-R56) [[2]](diffhunk://#diff-70d28618ab1eb1ee236a3e6c4fcf443e41b2796bca8b5ec4bacac5adee10cc87L10-R10) [[3]](diffhunk://#diff-70d28618ab1eb1ee236a3e6c4fcf443e41b2796bca8b5ec4bacac5adee10cc87R21-R25) [[4]](diffhunk://#diff-c2ca941cd7b806d0c7be05962ed2cb8960a82267c24956f5542982dc3230a879L39-R53) [[5]](diffhunk://#diff-c2ca941cd7b806d0c7be05962ed2cb8960a82267c24956f5542982dc3230a879R94-R102)

**Cache and Path Safety:**

* Moves the cache directory outside of `wwwroot` to prevent direct static serving of cached images, reducing the attack surface. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L28-R31) [[2]](diffhunk://#diff-d647708604415c7fc0be829b1b127b99586b596e658a3d05a62e29c7f386144eL57-R77)
* Normalizes and sanitizes requested image formats before using them in cache paths, preventing path traversal attacks via attacker-controlled query parameters. [[1]](diffhunk://#diff-ce0f493c3178b99139922f7b7557d313d7fc66456e297f4b09af439cb8a2b5c7R61-R68) [[2]](diffhunk://#diff-ce0f493c3178b99139922f7b7557d313d7fc66456e297f4b09af439cb8a2b5c7L69-R83)

**Response and Header Security:**

* Ensures that exception messages are not leaked to clients, logging detailed errors server-side and returning a generic message to prevent information disclosure.
* Sets the `X-Content-Type-Options: nosniff` header on all responses for defense-in-depth against MIME-type sniffing.
* Forces SVG images to be downloaded and sandboxed (never rendered inline) to prevent stored XSS via active SVG content.

These changes collectively harden the service against a range of security threats and improve its operational safety and reliability.